### PR TITLE
SHOULD fix use decoy

### DIFF
--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -2619,7 +2619,7 @@ Slots: [job.spawn_positions] [job.round_contrib_points ? "RCP: +[job.round_contr
 			for(var/X in L)
 				ADD_TRAIT(character, curse2trait(X), TRAIT_GENERIC)
 
-	if(taur_type)
+	if(taur_type && pref_species.allowed_taur_types.len != 0)
 		character.Taurize(taur_type, "#[taur_color]")
 	else if(character_setup)
 		// This should only ever ~do~ anything for previews


### PR DESCRIPTION
## About The Pull Request

Makes it so that taur variables aren't copied when the species don't support taurs. Should fix taurs being randomly applied accidently to incompatible species, such as through the usage of decoys.

## Testing Evidence

Unable to reproduce the decoy bug, but it does clear it when changing species or slots, which is the main thing this PR is supposed to do.

## Why It's Good For The Game

SHOULD fix use decoy, and maybe several other such edge case scenarios
