### PR TITLE
Atgervi weapon choices. Some Grenzelfencer adjustments

### DIFF
--- a/code/modules/jobs/job_types/roguetown/mercenaries/classes/atgervi.dm
+++ b/code/modules/jobs/job_types/roguetown/mercenaries/classes/atgervi.dm
@@ -20,12 +20,12 @@
 		/datum/skill/misc/swimming = SKILL_LEVEL_APPRENTICE,
 		/datum/skill/misc/climbing = SKILL_LEVEL_APPRENTICE,
 		/datum/skill/misc/sneaking = SKILL_LEVEL_APPRENTICE,
-		/datum/skill/combat/axes = SKILL_LEVEL_EXPERT,
+		/datum/skill/combat/axes = SKILL_LEVEL_JOURNEYMAN,
 		/datum/skill/combat/bows = SKILL_LEVEL_APPRENTICE,
 		/datum/skill/combat/wrestling = SKILL_LEVEL_JOURNEYMAN,
 		/datum/skill/combat/unarmed = SKILL_LEVEL_APPRENTICE,
 		/datum/skill/combat/swords = SKILL_LEVEL_APPRENTICE,
-		/datum/skill/combat/shields = SKILL_LEVEL_EXPERT,	
+		/datum/skill/combat/shields = SKILL_LEVEL_JOURNEYMAN,	
 		/datum/skill/combat/polearms = SKILL_LEVEL_APPRENTICE,
 		/datum/skill/combat/maces = SKILL_LEVEL_APPRENTICE,
 		/datum/skill/combat/knives = SKILL_LEVEL_APPRENTICE,
@@ -37,9 +37,30 @@
 /datum/outfit/job/roguetown/mercenary/atgervi
 	allowed_patrons = ALL_INHUMEN_PATRONS
 
-/datum/outfit/job/roguetown/mercenary/atgervi/pre_equip(mob/living/carbon/human/H)
+/datum/outfit/job/roguetown/mercenary/atgervi/pre_equip(mob/living/carbon/human/H) //CC Edit: Gives Varangians more weapon options.
 	..()
 	to_chat(H, span_warning("You are a Varangian of the Gronn Highlands. Warrior-Traders whose exploits into the Raneshen Empire will be forever remembered by historians."))
+	//CC EDIT
+	if (H.mind)
+		var/weapons = list("Greataxe", "Bearded Axe & Kite Shield", "Shortsword & Kite Shield")
+		var/weapon_choice = input("Choose your weapon.", "TAKE UP ARMS") as anything in weapons
+		switch(weapon_choice)
+			if("Greataxe")
+				H.adjust_skillrank_up_to(/datum/skill/combat/axes, 4, TRUE)
+				r_hand = /obj/item/rogueweapon/greataxe/steel
+				backr = /obj/item/rogueweapon/scabbard/gwstrap
+			if("Bearded Axe & Kite Shield")
+				H.adjust_skillrank_up_to(/datum/skill/combat/axes, 4, TRUE)
+				H.adjust_skillrank_up_to(/datum/skill/combat/shields, 4, TRUE)
+				beltl = /obj/item/rogueweapon/stoneaxe/woodcut/steel/atgervi
+				backr = /obj/item/rogueweapon/shield/atgervi
+			if ("Shortsword & Kite Shield")
+				H.adjust_skillrank_up_to(/datum/skill/combat/swords, 4, TRUE)
+				H.adjust_skillrank_up_to(/datum/skill/combat/shields, 4, TRUE)
+				r_hand = /obj/item/rogueweapon/sword/short/falchion
+				backr = /obj/item/rogueweapon/shield/atgervi
+				beltl = /obj/item/rogueweapon/scabbard/sword
+				// END CC EDIT
 	head = /obj/item/clothing/head/roguetown/helmet/bascinet/atgervi
 	gloves = /obj/item/clothing/gloves/roguetown/angle/atgervi
 	shirt = /obj/item/clothing/suit/roguetown/shirt/undershirt
@@ -47,12 +68,10 @@
 	pants = /obj/item/clothing/under/roguetown/trou/leather/atgervi
 	wrists = /obj/item/clothing/wrists/roguetown/bracers
 	shoes = /obj/item/clothing/shoes/roguetown/boots/leather/atgervi
-	backr = /obj/item/rogueweapon/shield/atgervi
 	backl = /obj/item/storage/backpack/rogue/satchel/black
-	beltr = /obj/item/rogueweapon/stoneaxe/woodcut/steel/atgervi
 	belt = /obj/item/storage/belt/rogue/leather
 	neck = /obj/item/clothing/neck/roguetown/chaincoif/chainmantle //They didn't have neck protection before.
-	beltl = /obj/item/storage/belt/rogue/pouch/coins/poor
+	beltr = /obj/item/storage/belt/rogue/pouch/coins/poor
 
 	var/datum/devotion/C = new /datum/devotion(H, H.patron)
 	C.grant_miracles(H, cleric_tier = CLERIC_T2, passive_gain = CLERIC_REGEN_WEAK, devotion_limit = CLERIC_REQ_2)	//Capped to T1 miracles.

--- a/code/modules/jobs/job_types/roguetown/mercenaries/classes/grenzelhoft.dm
+++ b/code/modules/jobs/job_types/roguetown/mercenaries/classes/grenzelhoft.dm
@@ -44,7 +44,6 @@
 		switch(weapon_choice)
 			if("Zweihander")
 				r_hand = /obj/item/rogueweapon/greatsword/grenz
-				beltl = /obj/item/flashlight/flare/torch/lantern
 			if("Kriegmesser & Buckler") // Buckler cuz they have no shield skill.
 				beltr = /obj/item/rogueweapon/scabbard/sword
 				r_hand = /obj/item/rogueweapon/sword/long/kriegmesser
@@ -128,7 +127,7 @@
 		)
 	H.merctype = 7
 //CC ADD
-/datum/advclass/mercenary/grenzelhoft/fencer // Experimental class! May need a balance pass.
+/datum/advclass/mercenary/grenzelhoft/fencer // Rebalanced a bit.
 	name = "Fechtenschutze"
 	tutorial = "You are a master fencer of the Zenitstadt fencing guild. You've abandoned the bulk of heavier armor in the name of perfecting each slash of your blade."
 	outfit = /datum/outfit/job/roguetown/mercenary/grenzelhoft_fencer
@@ -147,10 +146,10 @@
 		/datum/skill/misc/sneaking = SKILL_LEVEL_APPRENTICE,
 		/datum/skill/combat/wrestling = SKILL_LEVEL_JOURNEYMAN,
 		/datum/skill/combat/unarmed = SKILL_LEVEL_APPRENTICE,
-		/datum/skill/combat/swords = SKILL_LEVEL_EXPERT, //Veeeeery risky. Not sure this is the right call. Testing needed.
+		/datum/skill/combat/swords = SKILL_LEVEL_EXPERT,
 		/datum/skill/combat/knives = SKILL_LEVEL_APPRENTICE,
 		/datum/skill/misc/reading = SKILL_LEVEL_NOVICE,
-		/datum/skill/misc/athletics = SKILL_LEVEL_EXPERT,	// Staminachud mafia (needed for zwei)
+		/datum/skill/misc/athletics = SKILL_LEVEL_JOURNEYMAN
 	)
 
 /datum/outfit/job/roguetown/mercenary/grenzelhoft_fencer/pre_equip(mob/living/carbon/human/H)
@@ -171,9 +170,9 @@
 				r_hand = /obj/item/rogueweapon/sword/rapier
 				l_hand = /obj/item/rogueweapon/shield/buckler
 	//General gear regardless of class.
-	wrists = /obj/item/clothing/wrists/roguetown/bracers/leather
+	wrists = /obj/item/clothing/wrists/roguetown/bracers
 	belt = /obj/item/storage/belt/rogue/leather
-	//neck = /obj/item/clothing/neck/roguetown/leather
+	neck = /obj/item/clothing/neck/roguetown/gorget
 	shirt = /obj/item/clothing/suit/roguetown/shirt/undershirt
 	armor = /obj/item/clothing/suit/roguetown/armor/gambeson/heavy/grenzelhoft
 	//head = /obj/item/clothing/head/roguetown/grenzelhofthat


### PR DESCRIPTION
## About The Pull Request

Gives more weapon/armor options for Varangians. Reduces athletics of Grenzel fencers and gives them slightly better armor.

## Testing Evidence

<img width="515" height="372" alt="image" src="https://github.com/user-attachments/assets/77d98c4c-072d-4424-9986-e54c1c26ac7b" />

## Why It's Good For The Game

More choices is good, and historically speaking, the dane axe (what varangians actually used) was closer to our greataxe than anything else.

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
