### PR TITLE
Micro Holder Hearing Fix

### DIFF
--- a/modular_causticcove/code/modules/micromacrointeractions/microholder.dm
+++ b/modular_causticcove/code/modules/micromacrointeractions/microholder.dm
@@ -1,6 +1,7 @@
 /obj/item/micro
 	name = "micro"
 	desc = "A person? A toy? A snack? All three! They fit into your hand, how convinient!"
+	flags_1 = HEAR_1
 	var/mob/living/held_mob
 	var/matrix/original_transform
 	var/original_vis_flags = NONE


### PR DESCRIPTION
## About The Pull Request

Allows micros to see says and emotes when being held.

## Testing Evidence

Tested it via local and it seems to work.

## Why It's Good For The Game

Micros not hearing things is sad.