### PR TITLE
Campfire Rework/Tweak (However you view it)

### DIFF
--- a/code/datums/status_effects/rogue/roguebuff.dm
+++ b/code/datums/status_effects/rogue/roguebuff.dm
@@ -644,7 +644,7 @@
 		return
 	var/stamheal = healing_on_tick
 	if(!owner.cmode)
-		stamheal *= 2
+		stamheal *= 3 //CC Edit 2 -> 3 (15 Energy per tick)
 	owner.energy_add(stamheal)
 	owner.adjust_bodytemperature(8)
 
@@ -655,7 +655,7 @@
 	id = "healing_campfire"
 	alert_type = /atom/movable/screen/alert/status_effect/buff/healing/campfire
 	examine_text = null
-	var/healing_on_tick = 2
+	var/healing_on_tick = 3 //CC Edit, 2 -> 3 healing on tick. 
 	duration = 6 SECONDS
 
 /datum/status_effect/buff/campfire/tick()

--- a/code/datums/stress/positive_events.dm
+++ b/code/datums/stress/positive_events.dm
@@ -171,7 +171,7 @@
 	timer = 4 MINUTES
 
 /datum/stressevent/campfire
-	stressadd = -1
+	stressadd = -3	//CC Edit - Boost the mood bonus as compensation for requiring sleep to heal/regen energy.
 	desc = span_green("The warmth of the fire is comforting.")
 	timer = 5 MINUTES
 

--- a/code/game/objects/lighting/rogue_fires.dm
+++ b/code/game/objects/lighting/rogue_fires.dm
@@ -822,8 +822,8 @@
 			if(distance > healing_range || human.construct)
 				continue
 			human.add_stress(/datum/stressevent/campfire)
-
-			if(human.has_status_effect(/datum/status_effect/incapacitating/sleeping)) // CC Edit - Campfires only heal and boost energy regen when you're sleeping and laying down.
+			// CC Edit - Campfires only heal and boost energy regen when you're sleeping and laying down. For towners, this does not affect them.
+			if(human.has_status_effect(/datum/status_effect/incapacitating/sleeping) || human.job == "Towner" || istype(human.mind?.assigned_role, /datum/job/roguetown/villager))
 
 				if(!human.has_status_effect(/datum/status_effect/buff/campfire_stamina))
 					to_chat(human, span_info("The warmth of the fire comforts me, affording me a short rest. I would need to lie down on a bed to get a better rest."))

--- a/code/game/objects/lighting/rogue_fires.dm
+++ b/code/game/objects/lighting/rogue_fires.dm
@@ -821,24 +821,28 @@
 			var/distance = get_dist(src, human)
 			if(distance > healing_range || human.construct)
 				continue
-			if(!human.has_status_effect(/datum/status_effect/buff/campfire_stamina))
-				to_chat(human, span_info("The warmth of the fire comforts me, affording me a short rest. I would need to lie down on a bed to get a better rest."))
-			human.apply_status_effect(/datum/status_effect/buff/campfire_stamina)
 			human.add_stress(/datum/stressevent/campfire)
-			if(human.resting && !human.cmode)
-				var/valid_bed = FALSE
-				var/turf/T = get_turf(human)
-				for(var/obj/O in T.contents)
-					for(var/path in acceptable_beds)
-						if(ispath(O.type, path))
-							valid_bed = TRUE
+			
+			if(human.has_status_effect(/datum/status_effect/incapacitating/sleeping)) // CC Edit - Campfires only heal and boost energy regen when you're sleeping and laying down.
+
+				if(!human.has_status_effect(/datum/status_effect/buff/campfire_stamina))
+					to_chat(human, span_info("The warmth of the fire comforts me, affording me a short rest. I would need to lie down on a bed to get a better rest."))
+				human.apply_status_effect(/datum/status_effect/buff/campfire_stamina)
+
+				if(human.resting && !human.cmode)
+					var/valid_bed = FALSE
+					var/turf/T = get_turf(human)
+					for(var/obj/O in T.contents)
+						for(var/path in acceptable_beds)
+							if(ispath(O.type, path))
+								valid_bed = TRUE
+								break
+						if(valid_bed)
 							break
 					if(valid_bed)
-						break
-				if(valid_bed)
-					if(!human.has_status_effect(/datum/status_effect/buff/campfire))
-						to_chat(human, span_info("Settling in by the flames lifts the burdens of the week."))
-					human.apply_status_effect(/datum/status_effect/buff/campfire)
+						if(!human.has_status_effect(/datum/status_effect/buff/campfire))
+							to_chat(human, span_info("Settling in by the flames lifts the burdens of the week."))
+						human.apply_status_effect(/datum/status_effect/buff/campfire)
 
 
 /obj/machinery/light/rogue/campfire/onkick(mob/user)

--- a/code/game/objects/lighting/rogue_fires.dm
+++ b/code/game/objects/lighting/rogue_fires.dm
@@ -807,6 +807,7 @@
 	soundloop = /datum/looping_sound/fireloop
 	var/healing_range = 2
 	var/static/list/acceptable_beds = list(/obj/structure/bed, /obj/structure/flora/roguetree/stump, /obj/item/bedsheet)
+	var/greater_fire = FALSE //CC Edit
 
 /obj/machinery/light/rogue/campfire/process()
 	..()
@@ -823,7 +824,8 @@
 				continue
 			human.add_stress(/datum/stressevent/campfire)
 			// CC Edit - Campfires only heal and boost energy regen when you're sleeping and laying down. For towners, this does not affect them.
-			if(human.has_status_effect(/datum/status_effect/incapacitating/sleeping) || human.job == "Towner" || istype(human.mind?.assigned_role, /datum/job/roguetown/villager))
+			//If the campfire is a greater firepit (densefire), apply these effects anyways.
+			if(greater_fire || human.has_status_effect(/datum/status_effect/incapacitating/sleeping) || human.job == "Towner" || istype(human.mind?.assigned_role, /datum/job/roguetown/villager))
 
 				if(!human.has_status_effect(/datum/status_effect/buff/campfire_stamina))
 					to_chat(human, span_info("The warmth of the fire comforts me, affording me a short rest. I would need to lie down on a bed to get a better rest."))
@@ -875,6 +877,7 @@
 	bulb_colour = "#eea96a"
 	max_integrity = 60
 	healing_range = 4
+	greater_fire = TRUE //CC Edit
 
 /obj/machinery/light/rogue/campfire/densefire/CanPass(atom/movable/mover, turf/target)
 	if(istype(mover) && (mover.pass_flags & PASSTABLE))

--- a/code/game/objects/lighting/rogue_fires.dm
+++ b/code/game/objects/lighting/rogue_fires.dm
@@ -134,6 +134,7 @@
 	crossfire = FALSE
 	pixel_y = 32
 	healing_range = 2
+	greater_fire = TRUE //CC Edit
 
 /obj/machinery/light/rogue/campfire/fireplace/attack_hand(mob/user)
 	if(isliving(user) && on)

--- a/code/game/objects/lighting/rogue_fires.dm
+++ b/code/game/objects/lighting/rogue_fires.dm
@@ -822,7 +822,7 @@
 			if(distance > healing_range || human.construct)
 				continue
 			human.add_stress(/datum/stressevent/campfire)
-			
+
 			if(human.has_status_effect(/datum/status_effect/incapacitating/sleeping)) // CC Edit - Campfires only heal and boost energy regen when you're sleeping and laying down.
 
 				if(!human.has_status_effect(/datum/status_effect/buff/campfire_stamina))
@@ -842,7 +842,7 @@
 					if(valid_bed)
 						if(!human.has_status_effect(/datum/status_effect/buff/campfire))
 							to_chat(human, span_info("Settling in by the flames lifts the burdens of the week."))
-						human.apply_status_effect(/datum/status_effect/buff/campfire)
+						human.apply_status_effect(/datum/status_effect/buff/campfire) //CC Edit - See above comment.
 
 
 /obj/machinery/light/rogue/campfire/onkick(mob/user)

--- a/code/modules/roguetown/roguecrafting/structure.dm
+++ b/code/modules/roguetown/roguecrafting/structure.dm
@@ -885,8 +885,8 @@
 	name = "greater campfire"
 	category = "Misc"
 	result = /obj/machinery/light/rogue/campfire/densefire
-	reqs = list(/obj/item/grown/log/tree/stick = 2,
-				/obj/item/natural/stone = 2)
+	reqs = list(/obj/item/grown/log/tree/stick = 4,
+				/obj/item/natural/stone = 4) //CC Edit - Higher Cost for crafting in favor of good buffs regardless of resting. (From 2 for stones/sticks to 4 for stones/sticks)
 	verbage_simple = "build"
 	verbage = "builds"
 


### PR DESCRIPTION
## About The Pull Request

<!-- Describe your pull request here! Please describe and document all of the changes made in full. It helps maintainers go over everything and ensure that merges will run smoothly if needed, and that nothing is lost as more changes are made in the future! Last edited 1/14/26 by Jon -->

Campfires now only apply their buffs if you're actively ***ASLEEP*** by the campfire. No more can you heal by staring at a ceiling and going "I'm okay now. I feel better." 

In all seriousness however; This change is intended to bring back the necessities of actually preparing as opposed to getting free healing, and to put more risk into your campouts by actually needing to go to bed to get the bonuses to healing/energy recovery. No longer can mages sit around a fire and regen to max energy in a few seconds.

This effect does not apply to greater campfires (densefires), AKA fires with stones around them. That campfire has also had its recipe increased to 4 stones/4 sticks as opposed to just 2/2 stones/sticks.

As compensation for these changes: 

The campfire moodlet is now -3, instead of -1 (this is positive when we are talking about moods. This will make your character happier at a lower value and thus provide you with more fortune at high mood.)

Energy regeneration has increased from 10 -> 15

Health regeneration has increased from 2 -> 3 (Most minor wounds will close in 4 ticks as opposed to 5 ticks now for comparison.)

Towners are NOT affected by these changes, they can still get the campfire buffs like normal by standing/resting near them.


## Developer's checklist
<!--
Just a reminder to keep up the best practices, and to ensure that everyone has an easier time as a result! Please doublecheck that they were done!
-->
- [ ] Try to modularize as much as possible. <!--  Do this by putting stuff in the modular caustic folder, and modifying Azure code by calling your code from the places where you could put the code, for an example-->
- [x] Mark the start and end of edits outside the caustic modular folder (if applicable) for changes made.
<!--
Do this one like so

Azure
///Caustic edit
Your code
///Caustic edit end
Azure

This makes it easier for maintainers to keep track of what's ours.
-->
- [x] Ensure that it compiles locally, and test new features (when applicable, please record if not!), or potential issues with related features.

## Testing Evidence

<!-- Please provide evidence of testing features here, when applicable! If it is not, a quick note of this is fine. -->

## Why It's Good For The Game

<!-- What benefits does this bring to our server? How can it help players enjoy themselves more, or help lead players to more scenes? If it wasn't already chatted about over the Discord, feel free to explain your resoning and desire here for the change! Or feel free to add a link to the Discord's Suggestion thread for this change! -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- Please fill in any proper tags here that are valid for your PR! This is for the auto-changelog that is generated automatically and shown ingame. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
add: Added new mechanics or gameplay changes
add: Added more things
del: Removed old things
qol: made something easier to use
balance: rebalanced something
fix: fixed a few things
sound: added/modified/removed audio or sound effects
image: added/modified/removed some icons or images
map: added/modified/removed map content
spellcheck: fixed a few typos
code: changed some code
refactor: refactored some code
config: changed some config setting
admin: messed with admin stuff
server: something server ops should know
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
