### PR TITLE
Gnoll fixes

### DIFF
--- a/code/modules/antagonists/roguetown/villain/gnoll/gnoll_spells.dm
+++ b/code/modules/antagonists/roguetown/villain/gnoll/gnoll_spells.dm
@@ -208,7 +208,7 @@
 
 /obj/effect/proc_holder/spell/invoked/invisibility/gnoll
 	name = "Stalk"
-	desc = "Fade from view. Lasts longer if you are close to your sniffed prey. Far longer if they are hunted. Taking damage makes it impossible to go invisible for a minute."
+	desc = "Fade from view. Taking damage makes it impossible to go invisible for a minute."
 	var/obj/effect/proc_holder/spell/invoked/gnoll_sniff/sniff_spell
 	recharge_time = 2 MINUTES
 	overlay_icon = 'icons/mob/actions/gnollmiracles.dmi'
@@ -234,16 +234,8 @@
 		revert_cast()
 		return FALSE
 
-	var/base_dur = 5 SECONDS
+	var/base_dur = 999 MINUTES
 	var/bonus_dur = 0
-
-	if(sniff_spell && sniff_spell.tracked_target)
-		var/mob/living/prey = sniff_spell.tracked_target
-		if(get_dist(user, prey) <= 10)
-			to_chat(user, span_danger("My prey is close, my cloak lengthens."))
-			bonus_dur += 5 SECONDS // Small bonus for being close
-			if(prey.has_flaw(/datum/charflaw/hunted))
-				bonus_dur += 35 SECONDS // Massive bonus for hunted targets
 
 	var/total_dur = base_dur + bonus_dur
 

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/antag/gnoll.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/antag/gnoll.dm
@@ -35,7 +35,7 @@
 		/datum/virtue/utility/notable, //No resident (????) or free-money-stash gnolls
 		/datum/virtue/utility/bronzelimbs, //They should feel pain in their limbs given their state
 		/datum/virtue/movement/acrobatic, //This should be given to them when they are actually after a Hunted
-		/datum/virtue/utility/woodwalker, //This should be given to them when they are actually after a Hunted
+		///datum/virtue/utility/woodwalker, //This should be given to them when they are actually after a Hunted
 		/datum/virtue/combat/crossbowman,	//Absolutely not on a class like this
 		/datum/virtue/combat/bowman
 		)


### PR DESCRIPTION
## About The Pull Request

Fixes Gnoll to be more like how it was before the recent test merge.

## Testing Evidence
A small changes of values and commenting out a virtue_restricted.  Rand on a test server but it's hard to show just what was changed.

## Why It's Good For The Game

Brings gnolls back in line with how they were before the changes from upstream

## Changelog

:cl:
del: Removed woodwalker from the restricted virtues.
balance: Changed stalk back to infinite time instead of 5 seconds
:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
