### PR TITLE
Returns Authority to the Duke/Dutchess

### DIFF
--- a/code/game/objects/items/rogueweapons/melee/special.dm
+++ b/code/game/objects/items/rogueweapons/melee/special.dm
@@ -115,12 +115,13 @@
 
 		if(ishuman(target))
 			var/mob/living/carbon/human/H = target
-			var/area/target_area = get_area(H)
-
-			if(!istype(target_area, /area/rogue/indoors/town/manor))
-				to_chat(user, span_danger("The rod cannot be used on targets outside of the manor!"))
-				return
-
+			//CCedit: The Duke WILL have order in his lands!
+			//var/area/target_area = get_area(H)
+			
+			//if(!istype(target_area, /area/rogue/indoors/town/manor))
+				//to_chat(user, span_danger("The rod cannot be used on targets outside of the manor!"))
+				//return
+			//CCedit end
 			if(H == HU)
 				return
 


### PR DESCRIPTION
## About The Pull Request

Merely removed the area check that AP put on the master's rod for some reason; allowing the duke/dutchess to actually lay down the hammer either justly or because they are petty.
## Developer's checklist
<!--
Just a reminder to keep up the best practices, and to ensure that everyone has an easier time as a result! Please doublecheck that they were done!
-->
- [x ] Try to modularize as much as possible. <!--  Do this by putting stuff in the modular caustic folder, and modifying Azure code by calling your code from the places where you could put the code, for an example-->
- [x ] Mark the start and end of edits outside the caustic modular folder (if applicable) for changes made.
<!--
Do this one like so

Azure
///Caustic edit
Your code
///Caustic edit end
Azure

This makes it easier for maintainers to keep track of what's ours.
-->
- [ ] Ensure that it compiles locally, and test new features (when applicable, please record if not!), or potential issues with related features.

## Testing Evidence

<!-- Please provide evidence of testing features here, when applicable! If it is not, a quick note of this is fine. -->
I scoured the commit history

## Why It's Good For The Game

<!-- What benefits does this bring to our server? How can it help players enjoy themselves more, or help lead players to more scenes? If it wasn't already chatted about over the Discord, feel free to explain your resoning and desire here for the change! Or feel free to add a link to the Discord's Suggestion thread for this change! -->

Duke and Dutchess players from AP have been complaining that they don't get respect. Here's a reason why you don't get respect and the blocker on it removed! Go hog wild king!

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- Please fill in any proper tags here that are valid for your PR! This is for the auto-changelog that is generated automatically and shown ingame. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
balance: Removed the area limiter on the Master Rod
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
