### PR TITLE
Bone-Tweaking pass

### DIFF
--- a/code/datums/wounds/types/fractures.dm
+++ b/code/datums/wounds/types/fractures.dm
@@ -25,8 +25,8 @@
 	var/gain_emote = "paincrit"
 
 	// Limbs bleed worse, but bleed for far shorter periods than slashes etc.
-	bleed_rate = 15				// Artery is 20, but doesn't stop.
-	clotting_threshold = 0.25	// Grusome slash is 0.4
+	bleed_rate = 5				// CCedit arterys are 20
+	clotting_threshold = 0	// CCedit
 	clotting_rate = 0.60		// Normally it's only 0.02, this is huge compared to that.
 	bypass_bloody_wound_check = TRUE	//We bypass this proc-checkfor fractures.
 
@@ -143,6 +143,7 @@
 	)
 	embed_chance = 100	// Didn't we remove embeding..?
 	bleed_rate = 10		// Aooouuugh.. my brain..
+	clotting_threshold = 1 //CCedit, used the parent and we changed that
 	knockout = 20
 	paralysis = TRUE
 
@@ -231,7 +232,7 @@
 	mortal = FALSE
 	whp = 50
 	bleed_rate = 5				//Lower than others, still bad though. 
-	clotting_threshold = 0.3	//Slightly higher still
+	clotting_threshold = 0	//CCedit
 	clotting_rate = 0.1			//Slower clotting, not bad though for bleeder wound.
 
 /datum/wound/fracture/mouth/on_mob_gain(mob/living/affected)
@@ -283,9 +284,9 @@
 		"The ribcage caves in!",
 	)
 	whp = 50
-	bleed_rate = 25				//Higher than artery
-	clotting_threshold = 1		//Will always bleed bad
-	clotting_rate = 1			//Good clotting rate; within 24 ticks (~3 seconds) will lower heavily.
+	bleed_rate = 5				//CCedit, blood will not explode out of you now
+	clotting_threshold = 0		//CCedit, after being told how ribs work by three emts
+	clotting_rate = 0.5			//CCedit to reflect the above nerf
 
 /datum/wound/fracture/chest/on_mob_gain(mob/living/affected)
 	. = ..()
@@ -321,7 +322,7 @@
 	gain_emote = "groin"	//MY PIINTLE!!!!
 	mortal = FALSE
 	bleed_rate = 5
-	clotting_threshold = 1
+	clotting_threshold = 0 //CCedit
 	clotting_rate = 0.5
 
 /datum/wound/fracture/groin/on_mob_gain(mob/living/affected)


### PR DESCRIPTION
## About The Pull Request

Hi, the medical players don't like that blood just explodes out of people from bone breaks. Neither do the guard players who want to keep blood in people while they capture them. I'm sure gnolls and other kidnapping types would also like their playthings to not spontaneously shrivel like a raisin. This just nerfs a bunch of bleed rates based on what some actual physicians said the damage would realistically be. We'll have to feel it out together.

## Developer's checklist
<!--
Just a reminder to keep up the best practices, and to ensure that everyone has an easier time as a result! Please doublecheck that they were done!
-->
- [x ] Try to modularize as much as possible. <!--  Do this by putting stuff in the modular caustic folder, and modifying Azure code by calling your code from the places where you could put the code, for an example-->
- [ x] Mark the start and end of edits outside the caustic modular folder (if applicable) for changes made.
<!--
Do this one like so

Azure
///Caustic edit
Your code
///Caustic edit end
Azure

This makes it easier for maintainers to keep track of what's ours.
-->
- [ ] Ensure that it compiles locally, and test new features (when applicable, please record if not!), or potential issues with related features.

## Testing Evidence

<!-- Please provide evidence of testing features here, when applicable! If it is not, a quick note of this is fine. -->

## Why It's Good For The Game

Blood should stay in the body and I am tired of my lux donors losing all their blood after I clamp bleeders in them and rip their ribs open.
## Changelog
<!-- Please fill in any proper tags here that are valid for your PR! This is for the auto-changelog that is generated automatically and shown ingame. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->


balance: Made bone breaks not explode blood

/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
