### PR TITLE
More Descriptors!

### DIFF
--- a/code/datums/mob_descriptors/descriptors/body.dm
+++ b/code/datums/mob_descriptors/descriptors/body.dm
@@ -92,7 +92,7 @@
 /datum/mob_descriptor/body/massive
 	name = "Massive"
 
-/datum/mob_descriptor/body/hourglass-figured
+/datum/mob_descriptor/body/hourglass_figured
 	name = "Hourglass-figured"
 
 /datum/mob_descriptor/body/barrelchested

--- a/code/datums/mob_descriptors/descriptors/body.dm
+++ b/code/datums/mob_descriptors/descriptors/body.dm
@@ -89,7 +89,7 @@
 /datum/mob_descriptor/body/burly
 	name = "Burly"
 
-/datum/mob_descriptor/body/masive
+/datum/mob_descriptor/body/massive
 	name = "Massive"
 
 /datum/mob_descriptor/body/hourglass-figured

--- a/code/datums/mob_descriptors/descriptors/body.dm
+++ b/code/datums/mob_descriptors/descriptors/body.dm
@@ -88,3 +88,18 @@
 
 /datum/mob_descriptor/body/burly
 	name = "Burly"
+
+/datum/mob_descriptor/body/masive
+	name = "Massive"
+
+/datum/mob_descriptor/body/hourglass-figured
+	name = "Hourglass-figured"
+
+/datum/mob_descriptor/body/barrelchested
+	name = "Barrel-chested"
+
+/datum/mob_descriptor/body/brutish
+	name = "Brutish"
+
+/datum/mob_descriptor/body/absurd
+	name = "Absurd"

--- a/code/datums/mob_descriptors/descriptors/face.dm
+++ b/code/datums/mob_descriptors/descriptors/face.dm
@@ -153,3 +153,48 @@
 
 /datum/mob_descriptor/face_exp/smug
 	name = "Smug"
+
+/datum/mob_descriptor/face_exp/rabid
+	name = "Rabid"
+
+/datum/mob_descriptor/face_exp/uncomfortable
+	name = "Uncomfortable"
+
+/datum/mob_descriptor/face_exp/confused
+	name = "Confused"
+
+/datum/mob_descriptor/face_exp/drooly
+	name = "Drooly"
+
+/datum/mob_descriptor/face_exp/dopey
+	name = "Dopey"
+
+/datum/mob_descriptor/face_exp/crosseyed
+	name = "Cross-eyed"
+
+/datum/mob_descriptor/face_exp/giggly
+	name = "Giggly"
+
+/datum/mob_descriptor/face_exp/thirsty
+	name = "Thirsty"
+
+/datum/mob_descriptor/face_exp/dumb
+	name = "Dumb"
+
+/datum/mob_descriptor/face_exp/stupid
+	name = "Stupid"
+
+/datum/mob_descriptor/face_exp/nonchalant
+	name = "Nonchalant"
+
+/datum/mob_descriptor/face_exp/unbothered
+	name = "Unbothered"
+
+/datum/mob_descriptor/face_exp/tired
+	name = "Tired"
+
+/datum/mob_descriptor/face_exp/exhausted
+	name = "Exhausted"
+
+/datum/mob_descriptor/face_exp/bored
+	name = "Bored"

--- a/code/datums/mob_descriptors/descriptors/height.dm
+++ b/code/datums/mob_descriptors/descriptors/height.dm
@@ -36,7 +36,7 @@
 
 /datum/mob_descriptor/height/enormous
 	name = "Enormous"
-	prefix = "a"
+	prefix = "an"
 
 /datum/mob_descriptor/height/baothan
 	name = "Baothan"

--- a/code/datums/mob_descriptors/descriptors/height.dm
+++ b/code/datums/mob_descriptors/descriptors/height.dm
@@ -29,3 +29,19 @@
 /datum/mob_descriptor/height/tiny
 	name = "Tiny"
 	prefix = "a"
+
+/datum/mob_descriptor/height/massive
+	name = "Massive"
+	prefix = "a"
+
+/datum/mob_descriptor/height/enormous
+	name = "Enormous"
+	prefix = "a"
+
+/datum/mob_descriptor/height/baothan
+	name = "Baothan"
+	prefix = "a"
+
+/datum/mob_descriptor/height/skyscraping
+	name = "Sky-Scraping"
+	prefix = "a"

--- a/code/datums/mob_descriptors/descriptors/other.dm
+++ b/code/datums/mob_descriptors/descriptors/other.dm
@@ -50,6 +50,14 @@
 			adjective = "an average"
 		if(3)
 			adjective = "a large"
+		if(4)
+			adjective = "an extra-large"
+		if(5)
+			adjective = "a massive"
+		if(6)
+			adjective = "an enormous"
+		if(7)
+			adjective = "a downright Baothan"
 	var/list/arousal_data = list()
 	SEND_SIGNAL(H, COMSIG_SEX_GET_AROUSAL, arousal_data)
 	switch(arousal_data["arousal"])

--- a/code/datums/mob_descriptors/descriptors/prominent.dm
+++ b/code/datums/mob_descriptors/descriptors/prominent.dm
@@ -367,7 +367,7 @@
 	name = "Weak-Willed"
 	verbage = "%LOOKS%"
 
-/datum/mob_descriptor/prominent/vulpine_features
+/datum/mob_descriptor/prominent/slimy
 	name = "Slimy"
 	verbage = "%LOOKS%"
 

--- a/code/datums/mob_descriptors/descriptors/prominent.dm
+++ b/code/datums/mob_descriptors/descriptors/prominent.dm
@@ -346,3 +346,91 @@
 /datum/mob_descriptor/prominent/vulpine_features
 	name = "Vulpine Features"
 	verbage = "%HAVE%"
+
+/datum/mob_descriptor/prominent/thicker_than_hardtack
+	name = "Thicker than Hardtack"
+	verbage = "%ARE%"
+
+/datum/mob_descriptor/prominent/long_eared
+	name = "Long-eared"
+	verbage = "%ARE%"
+
+/datum/mob_descriptor/prominent/cushioned
+	name = "Cushioned"
+	verbage = "%ARE%"
+
+/datum/mob_descriptor/prominent/gloopy
+	name = "Gloopy"
+	verbage = "%ARE%"
+
+/datum/mob_descriptor/prominent/weak_willed
+	name = "Weak-Willed"
+	verbage = "%LOOKS%"
+
+/datum/mob_descriptor/prominent/vulpine_features
+	name = "Slimy"
+	verbage = "%LOOKS%"
+
+/datum/mob_descriptor/prominent/prominent_balls
+	name = "Prominent Ballsack"
+	verbage = "%HAVE%"
+
+/datum/mob_descriptor/prominent/prominent_shoulders
+	name = "Prominent Shoulders"
+	verbage = "%HAVE%"
+
+/datum/mob_descriptor/prominent/milky
+	name = "Milky"
+	verbage = "%ARE%"
+
+/datum/mob_descriptor/prominent/prominent_ears
+	name = "Prominent Ears"
+	verbage = "%HAVE%"
+
+/datum/mob_descriptor/prominent/acidicslime
+	name = "Acidic Slime"
+	verbage = "%HAVE%"
+
+/datum/mob_descriptor/prominent/toxicslime
+	name = "Toxic Slime"
+	verbage = "%HAVE%"
+
+/datum/mob_descriptor/prominent/causticslime
+	name = "Caustic Slime"
+	verbage = "%HAVE%"
+
+/datum/mob_descriptor/prominent/tastyslime
+	name = "Tasty Slime"
+	verbage = "%HAVE%"
+
+/datum/mob_descriptor/prominent/smelly
+	name = "Smelly"
+	verbage = "%ARE%"
+
+/datum/mob_descriptor/prominent/musky
+	name = "Musky"
+	verbage = "%ARE%"
+
+/datum/mob_descriptor/prominent/sweaty
+	name = "Sweaty"
+	verbage = "%ARE%"
+
+/datum/mob_descriptor/prominent/steamy
+	name = "Steamy"
+	verbage = "%ARE%"
+
+/datum/mob_descriptor/prominent/leaky
+	name = "Leaky"
+	verbage = "%ARE%"
+
+/datum/mob_descriptor/prominent/loud_genitals
+	name = "Loud Genitals"
+	verbage = "%HAVE%"
+
+/datum/mob_descriptor/prominent/overly_productive_genitals
+	name = "Overly Productive Genitals"
+	verbage = "%HAVE%"
+
+/datum/mob_descriptor/prominent/noisy_balls
+	name = "Noisy Balls"
+	verbage = "%HAVE%"

--- a/code/datums/mob_descriptors/descriptors/prominent.dm
+++ b/code/datums/mob_descriptors/descriptors/prominent.dm
@@ -374,6 +374,7 @@
 /datum/mob_descriptor/prominent/prominent_ballsack
 	name = "Prominent Ballsack"
 	verbage = "%HAVE%"
+	prefix = "a"
 
 /datum/mob_descriptor/prominent/prominent_shoulders
 	name = "Prominent Shoulders"

--- a/code/datums/mob_descriptors/descriptors/prominent.dm
+++ b/code/datums/mob_descriptors/descriptors/prominent.dm
@@ -371,7 +371,7 @@
 	name = "Slimy"
 	verbage = "%LOOKS%"
 
-/datum/mob_descriptor/prominent/prominent_balls
+/datum/mob_descriptor/prominent/prominent_ballsack
 	name = "Prominent Ballsack"
 	verbage = "%HAVE%"
 

--- a/code/datums/mob_descriptors/descriptors/stature.dm
+++ b/code/datums/mob_descriptors/descriptors/stature.dm
@@ -305,3 +305,6 @@
 
 /datum/mob_descriptor/stature/himbo
 	name = "Himbo"
+
+/datum/mob_descriptor/stature/chud
+	name = "Chud"

--- a/code/datums/mob_descriptors/descriptors/stature.dm
+++ b/code/datums/mob_descriptors/descriptors/stature.dm
@@ -65,6 +65,18 @@
 			return "antagonist"
 		else
 			return "antagonist"
+/datum/mob_descriptor/stature/bimbo
+	name = "Bimbo/Bimboy"
+/datum/mob_descriptor/stature/bimbo/get_description(mob/living/described)
+	switch(described.pronouns)
+		if(SHE_HER)
+			return "bimbo"
+		if(HE_HIM)
+			return "bimboy"
+		if(THEY_THEM)
+			return "bimbo"
+		else
+			return "bimbo"
 
 /datum/mob_descriptor/stature/thug
 	name = "Thug"
@@ -239,3 +251,57 @@
 
 /datum/mob_descriptor/stature/swashbuckler
 	name = "Swashbuckler"
+
+/datum/mob_descriptor/stature/fatass
+	name = "Fat-Ass"
+
+/datum/mob_descriptor/stature/grapplebait
+	name = "Grapplebait"
+
+/datum/mob_descriptor/stature/buttplug
+	name = "Buttplug" //might be too silly but im risking it
+
+/datum/mob_descriptor/stature/plug
+	name = "Plug"
+
+/datum/mob_descriptor/stature/snakeinthegrass
+	name = "Snake-In-The-Grass"
+
+/datum/mob_descriptor/stature/blob
+	name = "Blob"
+
+/datum/mob_descriptor/stature/thing
+	name = "Thing"
+
+/datum/mob_descriptor/stature/dummy
+	name = "Dummy"
+
+/datum/mob_descriptor/stature/coatrack
+	name = "Coatrack"
+
+/datum/mob_descriptor/stature/plushie
+	name = "Plushie"
+
+/datum/mob_descriptor/stature/doll
+	name = "Doll"
+
+/datum/mob_descriptor/stature/rat
+	name = "Rat"
+
+/datum/mob_descriptor/stature/doorbuster
+	name = "Door-buster"
+
+/datum/mob_descriptor/stature/fruit
+	name = "Fruit"
+
+/datum/mob_descriptor/stature/calamity
+	name = "Calamity"
+
+/datum/mob_descriptor/stature/dolt
+	name = "Dolt"
+
+/datum/mob_descriptor/stature/sumac
+	name = "Sumac"
+
+/datum/mob_descriptor/stature/himbo
+	name = "Himbo"

--- a/code/datums/mob_descriptors/descriptors/trait.dm
+++ b/code/datums/mob_descriptors/descriptors/trait.dm
@@ -238,3 +238,75 @@
 /datum/mob_descriptor/trait/volfish
 	name = "Volfish"
 	prefix = "%ARE% very"
+
+/datum/mob_descriptor/trait/plump
+	name = "Plump"
+	prefix = "%ARE% very"
+
+/datum/mob_descriptor/trait/fatassed
+	name = "Fat-Assed"
+	prefix = "%ARE% very"
+
+/datum/mob_descriptor/trait/bemused
+	name = "Bemused"
+	prefix = "%ARE% rather"
+
+/datum/mob_descriptor/trait/fat
+	name = "Fat"
+	prefix = "%ARE% very"
+
+/datum/mob_descriptor/trait/round
+	name = "Round"
+	prefix = "%ARE% very"
+
+/datum/mob_descriptor/trait/massive
+	name = "Massive"
+	prefix = "%ARE% very"
+
+/datum/mob_descriptor/trait/pearshaped
+	name = "Pear-Shaped"
+	prefix = "%ARE% very"
+
+/datum/mob_descriptor/trait/stomping
+	name = "Stomping"
+	prefix = "%ARE% very"
+
+/datum/mob_descriptor/trait/trotting
+	name = "Trotting"
+	prefix = "%ARE% very"
+
+/datum/mob_descriptor/trait/scampering
+	name = "Scampering"
+	prefix = "%ARE% very"
+
+/datum/mob_descriptor/trait/whiny
+	name = "Whiny"
+	prefix = "%ARE% very"
+
+/datum/mob_descriptor/trait/grippable
+	name = "Grippable"
+	prefix = "%ARE% very"
+
+/datum/mob_descriptor/trait/killable
+	name = "Killable"
+	prefix = "%ARE% very"
+
+/datum/mob_descriptor/trait/shiny
+	name = "Shiny"
+	prefix = "%ARE% very"
+
+/datum/mob_descriptor/trait/metal
+	name = "Metal"
+	prefix = "%ARE% very"
+
+/datum/mob_descriptor/trait/ravenous
+	name = "Ravenous"
+	prefix = "%ARE% very"
+
+/datum/mob_descriptor/trait/rotund
+	name = "Rotund"
+	prefix = "%ARE% very"
+
+/datum/mob_descriptor/trait/twozennies
+	name = "Two Zennies Short"
+	prefix = "%ARE% very"

--- a/code/datums/mob_descriptors/descriptors/voice.dm
+++ b/code/datums/mob_descriptors/descriptors/voice.dm
@@ -111,3 +111,21 @@
 
 /datum/mob_descriptor/voice/laconic
 	name = "Laconic"
+
+/datum/mob_descriptor/voice/rabid
+	name = "Rabid"
+
+/datum/mob_descriptor/voice/rousley
+	name = "Rous-ley"
+
+/datum/mob_descriptor/voice/angelic
+	name = "Angelic"
+
+/datum/mob_descriptor/voice/brassy
+	name = "Brassy"
+
+/datum/mob_descriptor/voice/ghostly
+	name = "Ghostly"
+
+/datum/mob_descriptor/voice/accented
+	name = "Accented"

--- a/code/modules/client/descriptors/descriptor_choice.dm
+++ b/code/modules/client/descriptors/descriptor_choice.dm
@@ -61,6 +61,21 @@
 		/datum/mob_descriptor/face_exp/suave,
 		/datum/mob_descriptor/face_exp/humble,
 		/datum/mob_descriptor/face_exp/smug,
+		/datum/mob_descriptor/face_exp/rabid,
+		/datum/mob_descriptor/face_exp/uncomfortable,
+		/datum/mob_descriptor/face_exp/confused,
+		/datum/mob_descriptor/face_exp/drooly,
+		/datum/mob_descriptor/face_exp/dopey,
+		/datum/mob_descriptor/face_exp/crosseyed,
+		/datum/mob_descriptor/face_exp/giggly,
+		/datum/mob_descriptor/face_exp/thirsty,
+		/datum/mob_descriptor/face_exp/dumb,
+		/datum/mob_descriptor/face_exp/stupid,
+		/datum/mob_descriptor/face_exp/nonchalant,
+		/datum/mob_descriptor/face_exp/unbothered,
+		/datum/mob_descriptor/face_exp/tired,
+		/datum/mob_descriptor/face_exp/exhausted,
+		/datum/mob_descriptor/face_exp/bored,
 	)
 
 /datum/descriptor_choice/body
@@ -96,6 +111,11 @@
 		/datum/mob_descriptor/body/broadshoulder,
 		/datum/mob_descriptor/body/waspwaist,
 		/datum/mob_descriptor/body/burly,
+		/datum/mob_descriptor/body/massive,
+		/datum/mob_descriptor/body/hourglass_figured,
+		/datum/mob_descriptor/body/barrelchested,
+		/datum/mob_descriptor/body/brutish,
+		/datum/mob_descriptor/body/absurd,
 	)
 
 /datum/descriptor_choice/stature
@@ -107,6 +127,7 @@
 		/datum/mob_descriptor/stature/hag,
 		/datum/mob_descriptor/stature/patriarch,
 		/datum/mob_descriptor/stature/villain,
+		/datum/mob_descriptor/stature/bimbo,
 		/datum/mob_descriptor/stature/thug,
 		/datum/mob_descriptor/stature/knave,
 		/datum/mob_descriptor/stature/wench,
@@ -171,6 +192,24 @@
 		/datum/mob_descriptor/stature/peon,
 		/datum/mob_descriptor/stature/scion,
 		/datum/mob_descriptor/stature/swashbuckler,
+		/datum/mob_descriptor/stature/fatass,
+		/datum/mob_descriptor/stature/grapplebait,
+		/datum/mob_descriptor/stature/buttplug,
+		/datum/mob_descriptor/stature/plug,
+		/datum/mob_descriptor/stature/snakeinthegrass,
+		/datum/mob_descriptor/stature/blob,
+		/datum/mob_descriptor/stature/thing,
+		/datum/mob_descriptor/stature/dummy
+		/datum/mob_descriptor/stature/coatrack,
+		/datum/mob_descriptor/stature/plushie,
+		/datum/mob_descriptor/stature/doll,
+		/datum/mob_descriptor/stature/rat,
+		/datum/mob_descriptor/stature/doorbuster,
+		/datum/mob_descriptor/stature/fruit,
+		/datum/mob_descriptor/stature/calamity,
+		/datum/mob_descriptor/stature/dolt,
+		/datum/mob_descriptor/stature/sumac,
+		/datum/mob_descriptor/stature/himbo,
 	)
 
 /datum/descriptor_choice/voice
@@ -209,6 +248,12 @@
 		/datum/mob_descriptor/voice/acerbic,
 		/datum/mob_descriptor/voice/caustic,
 		/datum/mob_descriptor/voice/laconic,
+		/datum/mob_descriptor/voice/rabid,
+		/datum/mob_descriptor/voice/rousley,
+		/datum/mob_descriptor/voice/angelic,
+		/datum/mob_descriptor/voice/brassy,
+		/datum/mob_descriptor/voice/ghostly,
+		/datum/mob_descriptor/voice/accented,
 	)
 
 /datum/descriptor_choice/skin
@@ -288,6 +333,10 @@
 		/datum/mob_descriptor/height/towering,
 		/datum/mob_descriptor/height/giant,
 		/datum/mob_descriptor/height/tiny,
+		/datum/mob_descriptor/height/massive,
+		/datum/mob_descriptor/height/enormous,
+		/datum/mob_descriptor/height/baothan,
+		/datum/mob_descriptor/height/skyscraping,
 	)
 /datum/descriptor_choice/trait
 	name = "Physical Descriptor"
@@ -352,6 +401,24 @@
 		/datum/mob_descriptor/trait/sullen,
 		/datum/mob_descriptor/trait/incessant,
 		/datum/mob_descriptor/trait/volfish,
+		/datum/mob_descriptor/trait/plump,
+		/datum/mob_descriptor/trait/fatassed,
+		/datum/mob_descriptor/trait/bemused,
+		/datum/mob_descriptor/trait/fat,
+		/datum/mob_descriptor/trait/round,
+		/datum/mob_descriptor/trait/massive,
+		/datum/mob_descriptor/trait/pearshaped,
+		/datum/mob_descriptor/trait/stomping,
+		/datum/mob_descriptor/trait/trotting,
+		/datum/mob_descriptor/trait/scampering,
+		/datum/mob_descriptor/trait/whiny,
+		/datum/mob_descriptor/trait/grippable,
+		/datum/mob_descriptor/trait/killable,
+		/datum/mob_descriptor/trait/shiny,
+		/datum/mob_descriptor/trait/metal,
+		/datum/mob_descriptor/trait/ravenous,
+		/datum/mob_descriptor/trait/rotund,
+		/datum/mob_descriptor/trait/twozennies,
 	)
 
 /datum/descriptor_choice/skin_all
@@ -443,6 +510,27 @@
 	/datum/mob_descriptor/prominent/chaste_mannerism,\
 	/datum/mob_descriptor/prominent/whimsy,\
 	/datum/mob_descriptor/prominent/dim_look,\
+	/datum/mob_descriptor/prominent/thicker_than_hardtack,\
+	/datum/mob_descriptor/prominent/long_eared,\
+	/datum/mob_descriptor/prominent/cushioned,\
+	/datum/mob_descriptor/prominent/gloopy,\
+	/datum/mob_descriptor/prominent/weak_willed,\
+	/datum/mob_descriptor/prominent/slimy,\
+	/datum/mob_descriptor/prominent/prominent_ballsack,\
+	/datum/mob_descriptor/prominent/prominent_shoulders,\
+	/datum/mob_descriptor/prominent/milky,\
+	/datum/mob_descriptor/prominent/prominent_ears,\
+	/datum/mob_descriptor/prominent/acidicslime,\
+	/datum/mob_descriptor/prominent/toxicslime,\
+	/datum/mob_descriptor/prominent/causticslime,\
+	/datum/mob_descriptor/prominent/tastyslime,\
+	/datum/mob_descriptor/prominent/smelly,\
+	/datum/mob_descriptor/prominent/musky,\
+	/datum/mob_descriptor/prominent/sweaty,\
+	/datum/mob_descriptor/prominent/leaky,\
+	/datum/mob_descriptor/prominent/loud_genitals,\
+	/datum/mob_descriptor/prominent/overly_productive_genitals,\
+	/datum/mob_descriptor/prominent/noisy_balls,\
 	/datum/mob_descriptor/prominent/custom/one,\
 	/datum/mob_descriptor/prominent/custom/two
 

--- a/code/modules/client/descriptors/descriptor_choice.dm
+++ b/code/modules/client/descriptors/descriptor_choice.dm
@@ -210,6 +210,7 @@
 		/datum/mob_descriptor/stature/dolt,
 		/datum/mob_descriptor/stature/sumac,
 		/datum/mob_descriptor/stature/himbo,
+		/datum/mob_descriptor/stature/chud,
 	)
 
 /datum/descriptor_choice/voice

--- a/code/modules/client/descriptors/descriptor_choice.dm
+++ b/code/modules/client/descriptors/descriptor_choice.dm
@@ -199,7 +199,7 @@
 		/datum/mob_descriptor/stature/snakeinthegrass,
 		/datum/mob_descriptor/stature/blob,
 		/datum/mob_descriptor/stature/thing,
-		/datum/mob_descriptor/stature/dummy
+		/datum/mob_descriptor/stature/dummy,
 		/datum/mob_descriptor/stature/coatrack,
 		/datum/mob_descriptor/stature/plushie,
 		/datum/mob_descriptor/stature/doll,


### PR DESCRIPTION
## About The Pull Request
Adds more Descriptors from my mind and a good bunch from the discord's suggestions.
<!-- Describe your pull request here! Please describe and document all of the changes made in full. It helps maintainers go over everything and ensure that merges will run smoothly if needed, and that nothing is lost as more changes are made in the future! Last edited 1/14/26 by Jon -->


## Testing Evidence

Compiled and ran fine, all options present.

## Why It's Good For The Game
Roleplay, babey.
<!-- What benefits does this bring to our server? How can it help players enjoy themselves more, or help lead players to more scenes? If it wasn't already chatted about over the Discord, feel free to explain your resoning and desire here for the change! Or feel free to add a link to the Discord's Suggestion thread for this change! -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
Physical Descriptors:

Plump
Fat-Assed(arsed?)
Bemused
Fat
Round
Massive
Pear-Shaped
Stomping
Trotting
Scampering
Whiny
Grippable
Killable
Shiny
Metal
Ravenous
Rotund
Two Zennies Short

Stature:

Fat-Ass(arse?)
Grapplebait (Might be a bit too silly)
Buttplug (MIGHT be too horny but yknow.)
Plug (Maybe a compromise)
Snake-In-The-Grass
Blob (Might be too horny)
Thing
Bimbo/Bimboy
Himbo
Dummy
Coatrack
Plushie (Maybe?)
Doll
Rat
Door-Buster
Fruit
Calamity
Dolt
Sumac
Himbo
Chud

Height:

Massive
Enormous
Baothan
Sky-Scraping

Body:
Massive
Hourglass-figured
Barrel-chested
Brutish
Absurd

Resting Expression:

Rabid
Uncomfortable
Confused
Drooly
Dopey
Cross-eyed
Giggly
Thirsty
Dumb (Or Stupid)
Nonchalant
Unbothered
Tired
Exhausted
Bored

Voice:

Rabid
Rous-ley
Angelic
Brassy
Ghostly
Accented

Prominent:

Thicker than Hardtack (Will proc the ass-clapping)
Long-eared
Cushioned
Gloopy
Weak-Willed
Slimy
Prominent Ballsack
Prominent Shoulders
Milky
Prominent Ears
Acidic Slime
Toxic Slime
Caustic Slime
Tasty Slime
Smelly
Musky
Sweaty
Steamy
Leaky
Loud Genitals
Overly Productive Genitals
Noisy Balls

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
