### PR TITLE
Fixes being unable to stake iron bars for scrap, increases scrap smithing amount

### DIFF
--- a/code/modules/roguetown/roguejobs/blacksmith/anvil_recipes/tools.dm
+++ b/code/modules/roguetown/roguejobs/blacksmith/anvil_recipes/tools.dm
@@ -414,10 +414,10 @@
 	createditem_num = 3
 
 /datum/anvil_recipe/tools/iron/scrap
-	name = "Pieces Of Scrap, Iron (x2)"
+	name = "Pieces Of Scrap, Iron (x6)"
 	req_bar = /obj/item/ingot/iron
 	created_item = /obj/item/scrap
-	createditem_num = 2
+	createditem_num = 6 // Caustic Edit / Makes smithing scrap more worth it than breaking down bars.
 
 /datum/anvil_recipe/tools/iron/cups
 	name = "Cups, Iron (x3)"

--- a/code/modules/roguetown/roguejobs/miner/rogueores.dm
+++ b/code/modules/roguetown/roguejobs/miner/rogueores.dm
@@ -152,6 +152,8 @@
 	grid_width = 64
 	grid_height = 32
 
+	obj_flags = CAN_BE_HIT // Caustic Edit / For a fix to make iron be able to be disassembled into scrap via a stake. This also makes ingots destructable, so be careful
+
 /obj/item/ingot/examine()
 	. += ..()
 	if(currecipe)


### PR DESCRIPTION
## About The Pull Request

Apparently trying to stake an iron bar to make scrap was broken for an unknown period of time.
It was an object flag issue, where most items were unable to be attacked, including all ingots. I made all ingots attackable.

This means that you can now make a lot of iron scrap decently quickly for repair kits or studded armor, as well as any heretics out there can style on the churchies and inquisition by taking a big hammer and smashing all their silver.

Also increased the scrap smithing amount from 2 pieces of scrap, to 6. This equals to 2 studded leather chestplates, 3 studded bikinis, 3 studded leather hoods, 1.5 scrap mantraps, 3 flint firestarters (crafting menu), or 1 full metal repair kit (3 scrap for empty, 3 to fill it).
