### PR TITLE
Add sanity check when splitting coins

### DIFF
--- a/code/game/objects/items/rogueitems/coins.dm
+++ b/code/game/objects/items/rogueitems/coins.dm
@@ -108,6 +108,8 @@
 		if(quantity == 1)
 			amt_text = ""
 		var/amount = input(user, "How many [plural_name] to split?[amt_text]", null, round(quantity/2, 1)) as null|num
+		if(QDELETED(user) || QDELETED(src) || !user.Adjacent(src)) // if coins were consumed/user was deleted/moved away, don't split
+			return
 		amount = clamp(amount, 0, quantity)
 		amount = round(amount, 1) // no taking non-integer coins
 		if(!amount)


### PR DESCRIPTION
This is a fix ported from upstream (https://github.com/Azure-Peak/Azure-Peak/pull/7327)

It fixes coin duplication

## About The Pull Request

This PR fixes two bugs when splitting piles of coins.

* It now checks if the location is reachable by the user
* It checks if the coins were consumed before trying to create a new pile

## Testing Evidence

I've tested this locally and confirm it works.

## Why It's Good For The Game

Fixes a bug that has existed for years.

## Changelog

:cl:
fix: Added guardrails for splitting coins logic
/:cl: