### PR TITLE
NUMEROUS HAG FIXES I SWEAR I'M DONE

### DIFF
--- a/_maps/map_files/cove_world/cove_CentCom.dmm
+++ b/_maps/map_files/cove_world/cove_CentCom.dmm
@@ -802,10 +802,6 @@
 "oc" = (
 /turf/open/floor/rogue/grass,
 /area/rogue/indoors/shelter/bog_hag)
-"oj" = (
-/obj/structure/roguemachine/hag_heart,
-/turf/open/floor/rogue/grassred,
-/area/rogue/indoors/shelter/bog_hag)
 "ol" = (
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors)
@@ -7452,7 +7448,7 @@ iH
 Iz
 Iz
 YM
-oj
+YM
 kp
 Iz
 Iz

--- a/_maps/map_files/cove_world/cove_wretch_coast.dmm
+++ b/_maps/map_files/cove_world/cove_wretch_coast.dmm
@@ -3489,6 +3489,10 @@
 "oE" = (
 /obj/machinery/light/rogue/candle,
 /obj/structure/rack/rogue/shelf/biggest,
+/obj/item/lockpickring/mundane,
+/obj/item/storage/belt/rogue/surgery_bag/full{
+	pixel_y = -5
+	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/shelter/bog_hag)
 "oF" = (

--- a/code/__DEFINES/traits.dm
+++ b/code/__DEFINES/traits.dm
@@ -568,8 +568,8 @@ GLOBAL_LIST_INIT(roguetraits, list(
 	TRAIT_ANCIENT_HAG = span_info("I know of secrets in alchemy and magyck no one else is aware of, for none are more ancient, more engrossed with the finer details of this land."),
 	TRAIT_WYRD_LABOURER = span_info("Strange power causes my swings to cut through trees and rocks with ease."),
 	TRAIT_CURSE_SCAR = span_info("That foul wench cursed me! I'll have my revenge... Those strange fog wards in the bog, what if?..."),
-	TRAIT_FEYTOUCHED = span_info("I've been influenced or created by fey, after offering lux to a heartroot, I can use it to travel."),
-	TRAIT_ROOT_WALKER = span_info("After offering lux, I can now travel along heartroot trees."),
+	TRAIT_FEYTOUCHED = span_info("I've been influenced or created by fey, I can use heartroot trees to travel."),
+	TRAIT_ROOT_WALKER = span_info("I can now travel along heartroot trees."),
 	TRAIT_WHITE_STAG = span_info("The power of the white stag lives on inside of me!"),
 	TRAIT_EDIT_DESCRIPTORS = span_info("I can change my appearance at a magic mirror in a thorough manner."),
 ))

--- a/code/modules/virtues/utility.dm
+++ b/code/modules/virtues/utility.dm
@@ -358,9 +358,9 @@
 // Hags don't get a boon on this person, that's perhaps a choice to add later.
 /datum/virtue/utility/feytouched
 	name = "Feytouched"
-	desc = "A vessel or creation of the Mossmother, or perhaps a puppet of the past. You are sympathetic to the hag's cause. Your connection to the fey allows you to offer lux or bloated leechticks and traverse the roots, though your mortal form is frail (-1 INT, -2 STR). The hag is aware of you; your lux is corrupted. You may know of old events, but as the decades lengthen, so does your recollection of them fade. Hag-boons cannot take hold."
-	added_stats = list(STATKEY_INT = -1, STATKEY_STR = -2)
-	added_traits = list(TRAIT_FEYTOUCHED)
+	desc = "A vessel or creation of the Mossmother, or perhaps a puppet of the past. You are sympathetic to the hag's cause. Your connection to the fey allows you to traverse the roots. The hag is aware of you; your lux is corrupted. You may know of old events, but as the decades lengthen, so does your recollection of them fade. Hag-boons cannot take hold."
+//	added_stats = list(STATKEY_INT = -1, STATKEY_STR = -2) //CC Edit - this sucks
+	added_traits = list(TRAIT_FEYTOUCHED, TRAIT_ROOT_WALKER) //CC Edit - added rootwalker. if you already have corrupted lux, why the fuck not just let them use the trees? this balancing is stupid.
 	added_skills = list(list(/datum/skill/misc/medicine, 1, 4),
 						list(/datum/skill/craft/alchemy, 1, 4)
 	)


### PR DESCRIPTION
## About The Pull Request

Does what the title says.

## Why It's Good For The Game

The old hag heart in centcom previously caused hag to have a chance to spawn there upon death, leading to being trapped forever, since the centcom hag area does not have a heartroot tree. Additionally returns the hag's surgical bag and lockpick tools to the proper hag area, as it's needed.

Additionally, changes the feytouched virtue to not suck massive nuts. The stat negatives were ass, and you couldn't even use the trees without sacrificing lux, and you couldn't use your OWN lux, because it was corrupted.
This lets feytouched use the trees without all that bullshit. Corrupted lux is enough of a negative.

also adds a mossmother tree in the center of the bog, because that was missing 

## Changelog

:cl:
fix: puts a mossmother tree in the bog
fix: removed redundant hag heart in centcom
qol: gives the new hag map a surgical bag and lockpick ring
qol: balances feytouched like a sane person
/:cl:

