### PR TITLE
The shovel update

### DIFF
--- a/code/modules/roguetown/roguejobs/gravedigger/tools.dm
+++ b/code/modules/roguetown/roguejobs/gravedigger/tools.dm
@@ -1,10 +1,12 @@
 /obj/item/rogueweapon/shovel
-	force = 21
+	force = 11
+	force_wielded = 21
 	possible_item_intents = list(/datum/intent/shovelscoop, /datum/intent/mace/strike/shovel)
 	gripped_intents = list(/datum/intent/shovelscoop, /datum/intent/mace/strike/shovel, /datum/intent/axe/chop/stone)
 	name = "shovel"
 	desc = "Essential for digging (graves) in this darkened earth."
 	icon_state = "shovel"
+	associated_skill = /datum/skill/combat/staves
 	icon = 'icons/roguetown/weapons/tools.dmi'
 	sharpness = IS_BLUNT
 	//dropshrink = 0.8
@@ -234,6 +236,7 @@
 	name = "spade"
 	desc = "Indispensable for tending the soil."
 	icon_state = "spade"
+	associated_skill = /datum/skill/combat/maces
 	sharpness = IS_BLUNT
 	//dropshrink = 0.8
 	gripped_intents = null
@@ -246,26 +249,32 @@
 
 /obj/item/rogueweapon/shovel/aalloy
 	force = 8
+	force_wielded = 18
 	name = "decrepit shovel"
 	desc = "A tool of wrought bronze, for burying the lyfeless. His worshippers would say that death is necessary; that the bod will nourish this world, so that more lyfe may sprout. But to those who know the truth - Her truth, it is nothing more than a mockery."
 	icon_state = "ashovel"
+	associated_skill = /datum/skill/combat/staves
 	smeltresult = /obj/item/ingot/aaslag
 	color = "#bb9696"
 	sellprice = 15
 
 /obj/item/rogueweapon/shovel/bronze
-	force = 23
+	force = 12
+	force_wielded = 22
 	name = "bronze shovel"
 	desc = "Dig the mound, so that water may flow into a thirsting crop. Puncture the earth, so that its depths may be catered to your whim. Leaven the soil, so that the buried may know peace from this world's evils."
 	icon_state = "bronzeshovel"
+	associated_skill = /datum/skill/combat/staves
 	smeltresult = /obj/item/ingot/bronze
 	max_integrity = 300
 
 /obj/item/rogueweapon/shovel/silver
-	force = 25
+	force = 13
+	force_wielded = 23
 	name = "silver shovel"
 	desc = "The only trait that distinguishes a man from a beast is their empathy. To mutilate the dead, regardless of what they've done in lyfe, is to invoke divine wrath. See them buried beneath crossed soil; ferry their spirit to the world beyond Psydonia, and towards their final judgement."
 	icon_state = "silvershovel"
+	associated_skill = /datum/skill/combat/staves
 	icon = 'icons/roguetown/weapons/misc32.dmi'
 	is_silver = TRUE
 	smeltresult = /obj/item/ingot/silver


### PR DESCRIPTION
## About The Pull Request

This PR adds stave skills to all two handed shovels and mace skill to the little cute one handed spade.
It also changed their force stats to be more inline, this is more of a buff to their wielded stats and a nerf to their unwielded stats. Still worse than proper quarterstaves.

## Testing Evidence

It compiled fine and I beat a humen over the head with a shovel until his head shattered so 

## Why It's Good For The Game

I noticed shovels don't have a skill, and while most "peasant/militia" weapons get a sort of farming or otherwise skill, I figured shovels could be staves because it is a woefully underutilized weapon skill, and also I think having a shovel be a characters "main weapon" would be really fun.

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- Please fill in any proper tags here that are valid for your PR! This is for the auto-changelog that is generated automatically and shown ingame. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
add: associated_skill = /datum/skill/combat/staves to all shovels
add: associated_skill = /datum/skill/combat/maces to the wooden spade
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
