### PR TITLE
Allows Mimic to be Killable With Cryo/Pyro/Fulg

### DIFF
--- a/code/modules/mob/living/simple_animal/rogue/creacher/mimic.dm
+++ b/code/modules/mob/living/simple_animal/rogue/creacher/mimic.dm
@@ -20,7 +20,7 @@
 	aggro_vision_range = 2
 	see_in_dark = 6
 
-	damage_coeff = list(BRUTE = 1, BURN = 0, TOX = 0, CLONE = 0, STAMINA = 0, OXY = 0)
+	damage_coeff = list(BRUTE = 0.5, BURN = 1, TOX = 0, CLONE = 0, STAMINA = 0, OXY = 0)
 	harm_intent_damage = 5
 	melee_damage_lower = 30
 	melee_damage_upper = 40

--- a/code/modules/mob/living/simple_animal/rogue/creacher/mimic.dm
+++ b/code/modules/mob/living/simple_animal/rogue/creacher/mimic.dm
@@ -20,7 +20,7 @@
 	aggro_vision_range = 2
 	see_in_dark = 6
 
-	damage_coeff = list(BRUTE = 0.5, BURN = 1, TOX = 0, CLONE = 0, STAMINA = 0, OXY = 0)
+	damage_coeff = list(BRUTE = 1, BURN = 1, TOX = 0, CLONE = 0, STAMINA = 0, OXY = 0)
 	harm_intent_damage = 5
 	melee_damage_lower = 30
 	melee_damage_upper = 40


### PR DESCRIPTION
Simple numbers change.

Allows Mimics to be killable with fire damage~~and nerfs damage from brute to them. Reason being is they are a beast with a hardened shell that is usually flamable, it shouldnt be easy to kill them with melee.~~

~~Half brute damage taken,~~ full damage from burns.

(can change these things on request)

Edit: I had neglected to realize they are already tanky enough vs melee so the brute damage change is unneeded.