### PR TITLE
More Fixing! (Reworked Graverobbing Penalty, Disabled Junk Lootspawns)

### DIFF
--- a/code/datums/loot_pool.dm
+++ b/code/datums/loot_pool.dm
@@ -65,7 +65,8 @@ GLOBAL_LIST_EMPTY(loot_pools_deferred_finalized)
 					funded_turfs += T
 					funded_types += S.type
 			else
-				S.spawn_junk()
+				//S.spawn_junk()
+				S.spawn_loot() //Caustic Edit - Lets... just try turning off the Junk by replacing it with more regular loot.
 				junk_count++
 			qdel(S)
 		else if(istype(spawner, /obj/structure/closet/crate/chest/loot_chest))
@@ -75,7 +76,8 @@ GLOBAL_LIST_EMPTY(loot_pools_deferred_finalized)
 				available_mammons -= C.loot_value
 				funded_count++
 			else
-				C.spawn_junk()
+				//C.spawn_junk()
+				C.generate_loot() //Caustic Edit - Lets... just try turning off the Junk by replacing it with more regular loot.
 				junk_count++
 		CHECK_TICK
 

--- a/code/datums/status_effects/status_effect.dm
+++ b/code/datums/status_effects/status_effect.dm
@@ -27,6 +27,15 @@
 	/// If defined, this text will appear when the mob is examined - to use he, she etc.
 	/// use "SUBJECTPRONOUN" and replace it in the examines themselves
 	var/examine_text
+	//Caustic Edit - Lets add a list to limit the examine text by Job, so Jobs can be defined to see the description, and not others.
+
+	//This text will appear to specific jobs as defined in the var below!
+	//Otherwise handled the same as above.
+	var/job_specific_examine
+	//Add a list of Job names to this variable and it will limit who can see the job-specific text by these jobs
+	var/specific_jobs
+	
+	//Caustic Edit End
 	/// The typepath to the alert thrown by the status effect when created.
 	/// Status effect "name"s and "description"s are shown to the owner here.
 	var/alert_type = /atom/movable/screen/alert/status_effect

--- a/code/datums/stress/positive_events.dm
+++ b/code/datums/stress/positive_events.dm
@@ -28,6 +28,11 @@
 	stressadd = -2
 	desc = span_green("I feel a soothing presence.")
 
+/datum/stressevent/minor_blessed
+	timer = 20 MINUTES
+	stressadd = -1
+	desc = span_green("I am watched over.")
+
 /datum/stressevent/triumph
 	timer = 10 MINUTES
 	stressadd = -5

--- a/code/game/objects/items/rogueitems/books.dm
+++ b/code/game/objects/items/rogueitems/books.dm
@@ -214,6 +214,10 @@
 			return
 		var/mob/living/to_bless = M
 		to_bless.apply_status_effect(/datum/status_effect/buff/blessed)
+		//Caustic Edit - Making this one override the minor-blessing from Orison!
+		if(to_bless.has_stress_event(/datum/stressevent/minor_blessed))
+			to_bless.remove_stress(/datum/stressevent/minor_blessed)
+		//Caustic Edit End
 		to_bless.add_stress(/datum/stressevent/blessed)
 		user.visible_message(span_notice("[user] blesses [M]."))
 		playsound(user, 'sound/magic/bless.ogg', 100, FALSE)

--- a/code/game/objects/lighting/_base_light.dm
+++ b/code/game/objects/lighting/_base_light.dm
@@ -236,9 +236,9 @@
 
 /obj/machinery/light/take_damage(damage_amount, damage_type = BRUTE, damage_flag = 0, sound_effect = 1)
 	. = ..()
-	if(. && !QDELETED(src))
+	/*if(. && !QDELETED(src)) //Caustic Edit - Lol. This was causing all "lights" to spark randomly if you hit them and they rolled the chance to "break the light tube". This includes Hearts, Cauldrons... anything like a Campfire.
 		if(prob(damage_amount * 5))
-			break_light_tube()
+			break_light_tube()*/
 
 
 

--- a/code/modules/jobs/job_types/roguetown/nobility/lord.dm
+++ b/code/modules/jobs/job_types/roguetown/nobility/lord.dm
@@ -84,6 +84,7 @@ GLOBAL_LIST_EMPTY(lord_titles)
 	beltr = /obj/item/rogueweapon/scabbard/sword/royal
 	backpack_contents = list(/obj/item/rogueweapon/huntingknife/idagger/steel/special = 1, /obj/item/blueprint/mace_mushroom = 1, /obj/item/hunting_map/white_stag = 1)
 	id = /obj/item/scomstone/garrison
+	l_hand = /obj/item/rogueweapon/lordscepter //Caustic Edit - Give back the Lord's Scepter
 
 /datum/outfit/job/roguetown/lord/pre_equip(mob/living/carbon/human/H)
 	..()
@@ -175,9 +176,9 @@ GLOBAL_LIST_EMPTY(lord_titles)
 		"Ducal Caparison (Saiga)" = /obj/item/caparison/azure,
 		"Fogbeast Caparison" = /obj/item/caparison/fogbeast)
 
-/datum/outfit/job/roguetown/lord/warrior/pre_equip(mob/living/carbon/human/H)
+/*/datum/outfit/job/roguetown/lord/warrior/pre_equip(mob/living/carbon/human/H)
 	..()
-	l_hand = /obj/item/rogueweapon/lordscepter
+	l_hand = /obj/item/rogueweapon/lordscepter*/ //Caustic Edit - commenting this out because moving it into the base Duke kit.
 
 /**
 	Merchant Lord subclass. Consider this an evolution from Sheltered Aristocrat.

--- a/code/modules/jobs/job_types/roguetown/nobility/lord.dm
+++ b/code/modules/jobs/job_types/roguetown/nobility/lord.dm
@@ -176,9 +176,9 @@ GLOBAL_LIST_EMPTY(lord_titles)
 		"Ducal Caparison (Saiga)" = /obj/item/caparison/azure,
 		"Fogbeast Caparison" = /obj/item/caparison/fogbeast)
 
-/*/datum/outfit/job/roguetown/lord/warrior/pre_equip(mob/living/carbon/human/H)
+/datum/outfit/job/roguetown/lord/warrior/pre_equip(mob/living/carbon/human/H)
 	..()
-	l_hand = /obj/item/rogueweapon/lordscepter*/ //Caustic Edit - commenting this out because moving it into the base Duke kit.
+	//l_hand = /obj/item/rogueweapon/lordscepter //Caustic Edit - commenting this out because moving it into the base Duke kit.
 
 /**
 	Merchant Lord subclass. Consider this an evolution from Sheltered Aristocrat.

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -804,7 +804,7 @@
 		msg += "[m1] soaked."
 
 	//Status effects
-	var/list/status_examines = status_effect_examines()
+	var/list/status_examines = status_effect_examines( , user) //Caustic Edit - Sending the viewer over to the status examines!
 	if(length(status_examines))
 		msg += status_examines
 
@@ -1118,7 +1118,7 @@
 
 	SEND_SIGNAL(src, COMSIG_PARENT_EXAMINE, user, .)
 
-/mob/living/proc/status_effect_examines(pronoun_replacement) //You can include this in any mob's examine() to show the examine texts of status effects!
+/mob/living/proc/status_effect_examines(pronoun_replacement, mob/user) //You can include this in any mob's examine() to show the examine texts of status effects!
 	var/list/dat = list()
 	if(!pronoun_replacement)
 		pronoun_replacement = p_they(TRUE)
@@ -1128,6 +1128,13 @@
 			var/new_text = replacetext(E.examine_text, "SUBJECTPRONOUN", pronoun_replacement)
 			new_text = replacetext(new_text, "[pronoun_replacement] is", "[pronoun_replacement] [p_are()]") //To make sure something become "They are" or "She is", not "They are" and "She are"
 			dat += "[new_text]\n" //dat.Join("\n") doesn't work here, for some reason
+		//Caustic Edit - Adding in the Job-specific examine texts for status effects!
+		if(E.job_specific_examine && E.specific_jobs && islist(E.specific_jobs))
+			if(user.job in E.specific_jobs)
+				var/new_text = replacetext(E.job_specific_examine, "SUBJECTPRONOUN", pronoun_replacement)
+				new_text = replacetext(new_text, "[pronoun_replacement] is", "[pronoun_replacement] [p_are()]") //To make sure something become "They are" or "She is", not "They are" and "She are"
+				dat += "[new_text]\n" //dat.Join("\n") doesn't work here, for some reason
+		//Caustic Edit End
 	if(dat.len)
 		return dat.Join()
 

--- a/code/modules/roguetown/roguejobs/gravedigger/hole.dm
+++ b/code/modules/roguetown/roguejobs/gravedigger/hole.dm
@@ -555,6 +555,8 @@
 	desc = "I feel... unlucky."
 	icon_state = "debuff"
 
+
+
 /obj/structure/closet/dirthole/MouseDrop_T(atom/movable/O, mob/living/user)
 	var/turf/T = get_turf(src)
 	if(istype(O, /obj/structure/closet/crate/coffin))

--- a/code/modules/roguetown/roguejobs/gravedigger/hole.dm
+++ b/code/modules/roguetown/roguejobs/gravedigger/hole.dm
@@ -531,7 +531,11 @@
 				if(isliving(user))
 					var/mob/living/L = user
 					if(!HAS_TRAIT(L, TRAIT_GRAVEROBBER))
-						L.apply_status_effect(/datum/status_effect/debuff/cursed)
+						var/datum/status_effect/debuff/cursed/curse = L.has_status_effect(/datum/status_effect/debuff/cursed)
+						if(!curse)
+							L.apply_status_effect(/datum/status_effect/debuff/cursed)
+						else
+							curse.increase_strength()
 			
 			stage = 3
 			climb_offset = 0
@@ -544,18 +548,69 @@
 		playsound(loc,'sound/items/dig_shovel.ogg', 100, TRUE)
 		return
 
+//Caustic Edit - Redoing this to make it actually a penalty to dig up graves...
 /datum/status_effect/debuff/cursed
 	id = "cursed"
+	job_specific_examine = "Necra's curse looms over this one... They did something to seriously anger her."
 	alert_type = /atom/movable/screen/alert/status_effect/debuff/cursed
 	effectedstats = list(STATKEY_LCK = -3)
-	duration = 10 MINUTES
+	duration = -1
+	var/strength = 1 //This will vary, increasing in strength for each grave defiled. The debuffs will get worse and more debilitating until removed!
+
+/datum/status_effect/debuff/cursed/on_creation(mob/living/new_owner, ...)
+	specific_jobs = GLOB.church_positions.Copy()
+
+	. = ..()
+
+/datum/status_effect/debuff/cursed/proc/increase_strength()
+	if(strength == 4)
+		return
+	
+	if(strength < 4)
+		strength += 1
+
+	switch(strength)
+		if(2)
+			to_chat(owner, "I feel Necra's gaze on me once more, and it's growing with intensity! She is angry with my actions.")
+			on_remove()
+			effectedstats = list(STATKEY_LCK = -4, STATKEY_CON = -1)
+			on_apply()
+		if(3)
+			to_chat(owner, "Again Necra's gaze turns to me, and she is very angry! I feel the curse strengthing further...")
+			on_remove()
+			effectedstats = list(STATKEY_LCK = -5, STATKEY_CON = -1, STATKEY_SPD = -1)
+			on_apply()
+		if(4)
+			to_chat(owner, "Necra is furious with me! I feel feeble and frail, but it doesn't feel like it will get any worse then this.")
+			on_remove()
+			effectedstats = list(STATKEY_LCK = -5, STATKEY_CON = -2, STATKEY_SPD = -1, STATKEY_STR = -1)
+			on_apply()
+			ADD_TRAIT(owner, TRAIT_CRITICAL_WEAKNESS, TRAIT_CURSE)
+
+/datum/status_effect/debuff/cursed/on_remove()
+	if(strength == 4 && HAS_TRAIT_FROM(owner, TRAIT_CRITICAL_WEAKNESS, TRAIT_CURSE))
+		REMOVE_TRAIT(owner, TRAIT_CRITICAL_WEAKNESS, TRAIT_CURSE)
+
+	. = ..()
 
 /atom/movable/screen/alert/status_effect/debuff/cursed
 	name = "Cursed"
-	desc = "I feel... unlucky."
+	desc = "Necra is displeased. I feel unlucky... Only a blessing from someone in good standing with the gods can help appease her."
 	icon_state = "debuff"
 
-
+/atom/movable/screen/alert/status_effect/proc/update_alert()
+	var/datum/status_effect/debuff/cursed/effect = attached_effect
+	if(!effect) //Just in case...
+		return
+	
+	switch(effect.strength)
+		if(2)
+			desc = "Necra is angry with me. I feel unlucky, and slightly frail. Only a blessing from someone in good standing with the gods can help appease her."
+		if(3)
+			desc = "Necra is very angry with me! I feel unlucky, slightly frail, and slow. Only a blessing from someone in good standing with the gods can help appease her."
+		if(4)
+			desc = "Necra is furious with me! I feel unlucky, frail, slow, and weak. A single lucky hit could really do some damage to me... Only a blessing from someone in good standing with the gods can help appease her."
+//Caustic Edit End
 
 /obj/structure/closet/dirthole/MouseDrop_T(atom/movable/O, mob/living/user)
 	var/turf/T = get_turf(src)

--- a/code/modules/spells/orison.dm
+++ b/code/modules/spells/orison.dm
@@ -211,7 +211,10 @@
 			if(curse)
 				qdel(curse)
 				to_chat(user, span_notice("I can feel Necra's curse leaving this one..."))
-	
+		else
+			if(!target.has_stress_event(/datum/stressevent/blessed))
+				target.add_stress(/datum/stressevent/minor_blessed)
+
 	return minor_blessing
 //Caustic Edit End
 

--- a/code/modules/spells/orison.dm
+++ b/code/modules/spells/orison.dm
@@ -24,7 +24,7 @@
 		<b>Touch</b>: Direct a sliver of divine thaumaturgy into your being, causing your voice to become LOUD when you next speak. Known to sometimes scare the rats inside the SCOMlines. Can be used on light sources at range, and it will cause them flicker. You may also use this to speak to others of the same patron, or to all if you're from the church. Aim for your MOUTH to speak to others, aim for your NECK to change who you direct your voice towards, and aim for your EARS to silence, or unsilence the utterances of others.\n \
 		<b>Use</b>: Issue a prayer for illumination, causing you or another living creature to begin glowing with light for five minutes - this stacks each time you cast it, with no upper limit. Using thaumaturgy on a person will remove this blessing from them, and MMB on your praying hand will remove any light blessings from yourself."
 	catchphrase = null
-	possible_item_intents = list(/datum/intent/fill, INTENT_HELP, /datum/intent/use)
+	possible_item_intents = list(/datum/intent/fill, INTENT_HELP, /datum/intent/use, /datum/intent/bless)
 	icon = 'icons/mob/roguehudgrabs.dmi'
 	icon_state = "pulling"
 	icon_state = "grabbing_greyscale"
@@ -34,6 +34,7 @@
 	var/thaumaturgy_devotion = 30 //CC Edit - Thaumaturgy has been buffed and tweaked, now costs 30 devotion to cast as opposed to 10. 
 	var/light_devotion = 5
 	var/water_moisten = 2
+	var/minor_blessing = 5 //Caustic Edit - A small thing for flavor, but it can also be used to remove the Necra Curse from Graverobbing, and more in the future.
 	var/speaking_to = SPEAKING_TO_ALL // CC Edit - Speak Defines for who we comm to. Defaults to all.
 	experimental_inhand = FALSE
 
@@ -90,6 +91,15 @@
 				user.devotion?.update_devotion(-fatigue_used)
 				qdel(src)
 			//CC Edit - Thaumaturgical Comms
+
+		//Caustic Edit - Adding in the Bless intent for flavor (and getting rid of Necra's Curse on Graverobbers!)
+		if(/datum/intent/bless)
+			fatigue_used = bless(target, user)
+			if (fatigue_used)
+				user.devotion?.update_devotion(-fatigue_used)
+				qdel(src)
+		//Caustic Edit End
+
 #define BLESSINGOFLIGHT_FILTER "bol_glow"
 
 /atom/movable/screen/alert/status_effect/light_buff
@@ -169,6 +179,41 @@
 	return light_devotion
 
 #undef BLESSINGOFLIGHT_FILTER
+
+//Caustic Edit - Add in the Bless option for Orison!
+/obj/item/melee/touch_attack/orison/proc/bless(atom/thing, mob/living/carbon/human/user)
+	var/holy_skill = user.get_skill_level(attached_spell.associated_skill)
+	var/cast_time = 35 - (holy_skill * 3)
+
+	if(!thing.Adjacent(user))
+		to_chat(user, span_info("I need to be next to [thing] to bless it!"))
+		return
+	
+	if(thing == user)
+		to_chat(user, span_info("I already can feel the gaze of [user.patron.name] on me. I don't need a minor blessing."))
+		return
+
+	if(!isliving(thing))
+		user.visible_message(span_notice("[user] makes a faithful gesture towards [thing], preparing a minor blessing..."), span_notice("[user.patron.name], please grant this a minor blessing..."))
+	else
+		user.visible_message(span_notice("[user] makes a faithful gesture towards [thing], preparing a minor blessing..."), span_notice("[user.patron.name], please grant them a minor blessing..."))
+
+	if(!do_after(user, cast_time, target = thing))
+		return
+	
+	if(!isliving(thing))
+		user.visible_message(span_notice("[user] finishes their prayer, bestowing a minor blessing on [thing]."), span_notice("I can feel the blessing of [user.patron.name]... [thing] is slightly sanctified."))
+	else
+		user.visible_message(span_notice("[user] finishes their prayer, bestowing a minor blessing on [thing]."), span_notice("I can feel the minor blessing taking hold on [thing], thank you [user.patron.name]."))
+		var/mob/living/target = thing
+		if(target && !user.has_status_effect(/datum/status_effect/debuff/cursed))
+			var/datum/status_effect/debuff/cursed/curse = target.has_status_effect(/datum/status_effect/debuff/cursed)
+			if(curse)
+				qdel(curse)
+				to_chat(user, span_notice("I can feel Necra's curse leaving this one..."))
+	
+	return minor_blessing
+//Caustic Edit End
 
 /atom/movable/screen/alert/status_effect/thaumaturgy
 	name = "Thaumaturgical Voice"

--- a/modular_causticcove/code/modules/vore/eating/belly_obj_liquid_choices.dm
+++ b/modular_causticcove/code/modules/vore/eating/belly_obj_liquid_choices.dm
@@ -14,7 +14,7 @@
 			if(reagent_name in our_reagents)
 				reagent_name = lowertext(REAGENT_WATER)
 			gen_amount = 2
-			gen_cost = 0
+			gen_cost = 1
 			reagentid = REAGENT_WATER
 			reagentcolor = "#0064C877"
 		if(REAGENT_WATER_BATH)


### PR DESCRIPTION
Some more changes! Here we go again!

Graverobbing now has a penalty again! The buff is infinite duration, and if you continue to dig up graves, it will get worse until it gives you Critical Weakness. After that you have a permanent stat negative and crit weakness. To get it removed, find someone with Orison and ask them for a Minor Blessing!
Orison now has the Bless intent! You can bless objects and people. It doesn't really do much for now, but adds Minor Stress reduction version of the Blessing from the Bishop, and no stat bonus. It will remove the Necra Graverobbing curse first, though! Then if you want the stress reduction, a second blessing is required.
Converted the SpawnJunk in the Lootpool system over to just SpawnLoot instead. Kinda hacky way to disable that, but it means we won't get shards and stuff in loot anymore.