### PR TITLE
Construct Balance Buff/Penalty Rework

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types/roguetown/construct/constructm.dm
+++ b/code/modules/mob/living/carbon/human/species_types/roguetown/construct/constructm.dm
@@ -755,19 +755,20 @@
 	owner.remove_stress(/datum/stressevent/integrity_rig)
 	. = ..()
 
+//Caustic Edit - Debuff Changed from -4WIL -1SPD to -1STR, -1WIL, -2SPD for Medium. -4WIL, -2SPD to -1STR, -1WIL, -3SPD for Heavy
 /datum/status_effect/debuff/ironman_medium
 	id = "ironman_medium"
 	alert_type = /atom/movable/screen/alert/status_effect/debuff/ironman_medium
-	effectedstats = list(STATKEY_WIL = -4, STATKEY_SPD = -1)
+	effectedstats = list(STATKEY_STR = -1, STATKEY_WIL = -1, STATKEY_SPD = -2)
 /atom/movable/screen/alert/status_effect/debuff/ironman_medium
 	name = "Metal Fatigue I"
 	desc = "My frame bears needless burden. Additional metal drags at my joints and dulls the rhythm of my workings."
 	icon_state = "muscles"
-
+ 
 /datum/status_effect/debuff/ironman_heavy
 	id = "ironman_heavy"
 	alert_type = /atom/movable/screen/alert/status_effect/debuff/ironman_heavy
-	effectedstats = list(STATKEY_WIL = -4, STATKEY_SPD = -2)
+	effectedstats = list(STATKEY_STR = -1, STATKEY_WIL = -1, STATKEY_SPD = -3)
 /atom/movable/screen/alert/status_effect/debuff/ironman_heavy
 	name = "Metal Fatigue II"
 	desc = "My frame labors under excess weight. Every motion grinds, every step strains more than they should."

--- a/code/modules/mob/living/carbon/human/species_types/roguetown/construct/constructm.dm
+++ b/code/modules/mob/living/carbon/human/species_types/roguetown/construct/constructm.dm
@@ -764,7 +764,7 @@
 	name = "Metal Fatigue I"
 	desc = "My frame bears needless burden. Additional metal drags at my joints and dulls the rhythm of my workings."
 	icon_state = "muscles"
- 
+
 /datum/status_effect/debuff/ironman_heavy
 	id = "ironman_heavy"
 	alert_type = /atom/movable/screen/alert/status_effect/debuff/ironman_heavy


### PR DESCRIPTION
## About The Pull Request

The Previous Stat penalty of -4 WIL was insanely penalizing. Constructs have been getting a good degree of trickle-down nerfs from all the content and stuff being added. The fact they couldn't wear medium or heavy armor was understandably debuffed but perhaps too much. Constructs should be able to wear medium and heavy armors now at a cost that does make them weaker but doesn't just absolutely neuter their stamina

## Developer's checklist
<!--
Just a reminder to keep up the best practices, and to ensure that everyone has an easier time as a result! Please doublecheck that they were done!
-->
- [x] Try to modularize as much as possible. <!--  Do this by putting stuff in the modular caustic folder, and modifying Azure code by calling your code from the places where you could put the code, for an example-->
- [x] Mark the start and end of edits outside the caustic modular folder (if applicable) for changes made.
<!--
Do this one like so

Azure
///Caustic edit
Your code
///Caustic edit end
Azure

This makes it easier for maintainers to keep track of what's ours.
-->
- [x] Ensure that it compiles locally, and test new features (when applicable, please record if not!), or potential issues with related features.

## Testing Evidence

<!-- Please provide evidence of testing features here, when applicable! If it is not, a quick note of this is fine. -->

## Why It's Good For The Game

<!-- What benefits does this bring to our server? How can it help players enjoy themselves more, or help lead players to more scenes? If it wasn't already chatted about over the Discord, feel free to explain your resoning and desire here for the change! Or feel free to add a link to the Discord's Suggestion thread for this change! -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- Please fill in any proper tags here that are valid for your PR! This is for the auto-changelog that is generated automatically and shown ingame. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
balance: Rebalances Construct Debuff numbers for Wearing Medium and Heavy Armor
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
