### PR TITLE
Pastafazool I am a fool (A few minor fixes (Colored giltsilk names, mole fur, butchery fix(?)))

### DIFF
--- a/code/game/objects/items/rogueitems/natural/animals.dm
+++ b/code/game/objects/items/rogueitems/natural/animals.dm
@@ -79,7 +79,7 @@
 /obj/item/natural/fur/direbear
 	desc = "Fur from one of Dendor's mightiest creachers."
 	icon_state = "pelt_direbear"
-	color = "#33302b"
+	color = null
 	sellprice = 28
 
 /obj/item/natural/fur/rabbit
@@ -216,8 +216,8 @@
 	sellprice = 20
 
 /obj/item/natural/rabbitsfoot
-	name = "rabbit's foot"
+	name = "cabbit's foot"
 	icon_state = "rabbitfoot"
-	desc = "A rabbit's foot. A lucky charm."
+	desc = "A cabbit's foot. A lucky charm."
 	w_class = WEIGHT_CLASS_TINY
 	sellprice = 10

--- a/code/modules/mob/living/simple_animal/rogue/creacher/mole.dm
+++ b/code/modules/mob/living/simple_animal/rogue/creacher/mole.dm
@@ -16,14 +16,14 @@
 	botched_butcher_results = list(/obj/item/reagent_containers/food/snacks/rogue/meat/steak = 2, /obj/item/alch/viscera = 1)
 	butcher_results = list(/obj/item/reagent_containers/food/snacks/rogue/meat/steak = 3,
 						/obj/item/natural/hide = 2,
-						/obj/item/natural/fur = 1,
+						/obj/item/natural/fur/mole = 1,
 						/obj/item/natural/bone = 3,
 						/obj/item/alch/sinew = 3,
 						/obj/item/alch/bone = 1,
 						/obj/item/alch/viscera = 1)
 	perfect_butcher_results = list(/obj/item/reagent_containers/food/snacks/rogue/meat/steak = 5,
 						/obj/item/natural/hide = 3,
-						/obj/item/natural/fur = 2,
+						/obj/item/natural/fur/mole = 2,
 						/obj/item/natural/bone = 3,
 						/obj/item/alch/sinew = 3,
 						/obj/item/alch/bone = 1,

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -607,7 +607,16 @@ GLOBAL_VAR_INIT(farm_animals, FALSE)
 	var/list/dna_to_add // Copied over from the gibspawner.dm and trimmed down, so that gibs have a bloodtype? If it matters?
 	dna_to_add = list("Non-human DNA" = random_blood_type())
 
-	for(var/path in butcher_results)
+	// Caustic Edit
+	// If the perfect butcher results have more paths, they will no longer be ignored, allowing for things like rous fur, or cabbit feet to be acquired
+	var/list/list_to_use = butcher_results
+	if(initial(length(perfect_butcher_results)) > initial(length(butcher_results))) // If it's stupid and it works, is it stupid? (Please tell me if there's a better way to do this, I couldn't find anything)
+	// Prevents stopping a butchery mid-way and restarting it to get doubled loot as it re-checks the lists.
+		list_to_use = perfect_butcher_results
+
+	// Caustic Edit End
+
+	for(var/path in list_to_use) // Caustic Edit
 		var/amount = butcher_results[path]
 		if(!do_after(user, time_per_cut, target = src))
 			if(botch_count || normal_count || perfect_count)
@@ -633,7 +642,9 @@ GLOBAL_VAR_INIT(farm_animals, FALSE)
 		else
 			normal_count++
 
-		butcher_results -= path
+		list_to_use -= path
+		if(!length(list_to_use))
+			amount = 0
 
 		// Spawn the item(s)
 		for(var/j in 1 to amount)
@@ -648,7 +659,7 @@ GLOBAL_VAR_INIT(farm_animals, FALSE)
 		if(user.mind)
 			user.mind.add_sleep_experience(/datum/skill/labor/butchering, user.STAINT * 0.5)
 		playsound(src, 'sound/foley/gross.ogg', 100, FALSE)
-	if(isemptylist(butcher_results))
+	if(isemptylist(list_to_use))
 		if(head_butcher)
 			var/head_path = head_butcher
 			head_butcher = null

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -642,9 +642,9 @@ GLOBAL_VAR_INIT(farm_animals, FALSE)
 		else
 			normal_count++
 
-		list_to_use -= path
-		if(!length(list_to_use))
+		if(!length(list_to_use) || !amount) // Caustic Edit. If the list is empty, or there isn't an item set, set the amount to 0 to prevent a runtime and corpses not finishing butchering.
 			amount = 0
+		list_to_use -= path
 
 		// Spawn the item(s)
 		for(var/j in 1 to amount)

--- a/code/modules/roguetown/roguecrafting/structure.dm
+++ b/code/modules/roguetown/roguecrafting/structure.dm
@@ -1589,7 +1589,6 @@
 	result = /obj/structure/giantfur
 	reqs = list(/obj/item/natural/fur = 3)
 	craftdiff = 0
-	subtype_reqs = FALSE // Allows using any furs
 
 /datum/crafting_recipe/roguetown/structure/furrugsmall
 	name = "giant fur pelt"
@@ -1597,7 +1596,6 @@
 	result = /obj/structure/giantfur/small
 	reqs = list(/obj/item/natural/fur = 2)
 	craftdiff = 0
-	subtype_reqs = FALSE // Allows using any furs
 
 /datum/crafting_recipe/roguetown/structure/floorcandle
 	name = "floor candles"

--- a/modular_deserttown/desertclothing.dm
+++ b/modular_deserttown/desertclothing.dm
@@ -670,96 +670,76 @@
 	icon_state = "jafar"
 	sellprice = 30
 
-/obj/item/storage/belt/rogue/leather/exoticsilkbelt/skirtgreen
-	name = "green exotic silk skirt"
-	desc = "A gold adorned belt with the softest of silk skirts barely concealing one's bits."
+/obj/item/storage/belt/rogue/leather/silkbelt/skirtgreen
+	name = "green giltsilk skirt"
 	icon = 'modular_deserttown/icons/clothing/belts.dmi'
 	mob_overlay_icon = 'modular_deserttown/icons/clothing/onmob/belts.dmi'
-	salvage_result = /obj/item/natural/silk
-	salvage_amount = 1
 	icon_state = "exoticsilkskirt2"
 	item_state = "exoticsilkskirt2"
 
-/datum/crafting_recipe/roguetown/sewing/skirtgreen
-	name = "exotic silk belt (green)"
-	result = list(/obj/item/storage/belt/rogue/leather/exoticsilkbelt/skirtgreen)
-	reqs = list(/obj/item/natural/silk = 2)
-	craftdiff = 4
+/datum/crafting_recipe/roguetown/sewing/silkbelt/green
+	name = "giltsilk belt (green)"
+	result = list(/obj/item/storage/belt/rogue/leather/silkbelt/skirtgreen)
 
-/obj/item/storage/belt/rogue/leather/exoticsilkbelt/skirtred
-	name = "red exotic silk skirt"
-	desc = "A gold adorned belt with the softest of silk skirts barely concealing one's bits."
+/obj/item/storage/belt/rogue/leather/silkbelt/skirtred
+	name = "red giltsilk skirt"
 	icon = 'modular_deserttown/icons/clothing/belts.dmi'
 	mob_overlay_icon = 'modular_deserttown/icons/clothing/onmob/belts.dmi'
-	salvage_result = /obj/item/natural/silk
-	salvage_amount = 1
 	icon_state = "exoticsilkskirt"
 	item_state = "exoticsilkskirt"
 
-/datum/crafting_recipe/roguetown/sewing/skirtred
-	name = "exotic silk belt (red)"
-	result = list(/obj/item/storage/belt/rogue/leather/exoticsilkbelt/skirtred)
-	reqs = list(/obj/item/natural/silk = 2)
-	craftdiff = 4
+/datum/crafting_recipe/roguetown/sewing/silkbelt/red
+	name = "giltsilk belt (red)"
+	result = list(/obj/item/storage/belt/rogue/leather/silkbelt/skirtred)
 
 ////////
 
-/obj/item/clothing/suit/roguetown/shirt/exoticsilkbra/green
+/obj/item/clothing/suit/roguetown/shirt/silkbra/green
+	name = "green giltsilk bra"
 	icon = 'modular_deserttown/icons/clothing/shirts.dmi'
 	mob_overlay_icon = 'modular_deserttown/icons/clothing/onmob/shirts.dmi'
-	salvage_result = /obj/item/natural/silk
-	salvage_amount = 1
 	icon_state = "exoticsilkbrag"
 	item_state = "exoticsilkbrag"
 
-/datum/crafting_recipe/roguetown/sewing/bragreen
-	name = "exotic silk bra(green)"
-	result = list(/obj/item/clothing/suit/roguetown/shirt/exoticsilkbra/green)
-	reqs = list(/obj/item/natural/silk = 2)
-	craftdiff = 4
+/datum/crafting_recipe/roguetown/sewing/silkbra/green
+	name = "giltsilk bra(green)"
+	result = list(/obj/item/clothing/suit/roguetown/shirt/silkbra/green)
 
-/obj/item/clothing/suit/roguetown/shirt/exoticsilkbra/red
+/obj/item/clothing/suit/roguetown/shirt/silkbra/red
+	name = "red giltsilk bra"
 	desc = "Fanciful gold laced silks barely able to conceal what little it covers. Long, flowing sleeves droop from the upper arms to a ring on each hand, fluttering in the wind and with every movement."
 	icon = 'modular_deserttown/icons/clothing/shirts.dmi'
 	mob_overlay_icon = 'modular_deserttown/icons/clothing/onmob/shirts.dmi'
-	salvage_result = /obj/item/natural/silk
-	salvage_amount = 1
 	icon_state = "exoticsilkbrar"
 	item_state = "exoticsilkbrar"
 
-/datum/crafting_recipe/roguetown/sewing/brared
-	name = "exotic silk bra (red)"
-	result = list(/obj/item/clothing/suit/roguetown/shirt/exoticsilkbra/red)
-	reqs = list(/obj/item/natural/silk = 2)
-	craftdiff = 4
+/datum/crafting_recipe/roguetown/sewing/silkbra/red
+	name = "giltsilk bra (red)"
+	result = list(/obj/item/clothing/suit/roguetown/shirt/silkbra/red)
 
-/obj/item/clothing/mask/rogue/exoticsilkmask/green
+/obj/item/clothing/mask/rogue/silkmask/green
+	name = "green giltsilk mask"
 	icon = 'modular_deserttown/icons/clothing/masks.dmi'
 	mob_overlay_icon = 'modular_deserttown/icons/clothing/onmob/masks.dmi'
-	salvage_result = /obj/item/natural/silk
-	salvage_amount = 1
 	icon_state = "exoticsilkmaskg"
 	item_state = "exoticsilkmaskg"
 
-/datum/crafting_recipe/roguetown/sewing/maskgreen
-	name = "exotic silk mask (green)"
-	result = list(/obj/item/clothing/mask/rogue/exoticsilkmask/green)
+/datum/crafting_recipe/roguetown/sewing/silkmaskgreen
+	name = "giltsilk mask (green)"
+	result = list(/obj/item/clothing/mask/rogue/silkmask/green)
 	reqs = list(/obj/item/natural/silk = 2)
 	craftdiff = 4
 
-/obj/item/clothing/mask/rogue/exoticsilkmask/red
+/obj/item/clothing/mask/rogue/silkmask/red
+	name = "red giltsilk mask"
 	icon = 'modular_deserttown/icons/clothing/masks.dmi'
 	mob_overlay_icon = 'modular_deserttown/icons/clothing/onmob/masks.dmi'
-	salvage_result = /obj/item/natural/silk
-	salvage_amount = 1
 	icon_state = "exoticsilkmaskr"
 	item_state = "exoticsilkmaskr"
 
-/datum/crafting_recipe/roguetown/sewing/maskred
-	name = "exotic silk mask (red)"
-	result = list(/obj/item/clothing/mask/rogue/exoticsilkmask/red)
-	reqs = list(/obj/item/natural/silk = 2)
-	craftdiff = 4
+/datum/crafting_recipe/roguetown/sewing/silkmask/red
+	name = "giltsilk mask (red)"
+	result = list(/obj/item/clothing/mask/rogue/silkmask/red)
 
 //Because some people can't live without BiS
 /obj/item/clothing/shoes/roguetown/shalal/reinforced


### PR DESCRIPTION
## About The Pull Request

There was a bug report in the discord that stated that the colored giltsilk stuff ported from deserttown didn't have names. They were also weirdly subtyped as `exoticsilkbelt/red` instead of being the normal giltsilk's (`silkbelt`) subtype. I changed that

I had forgotten to remove the `subtype_reqs = FALSE` from the giant fur/giant pelt recipes, which made them need base fur. Now it can use any fur type.

Moles dropped generic, untyped fur, despite there being a /mole fur subtype. Now they drop their own specific fur.
Direbear furs suddenly turned black when butchering. The uncolored sprite looks nice, and fits the mob sprite better.

A lot of mobs have their `perfect_butcher_results` list longer than the regular `butcher_results` one, which in most cases caused them to not even check the last perfect results. I added a check in the butchery proc to see which of the (initial) list length is longer, and use that count for checking loot. As far as I tested, it didn't cause any weirdness.

---

<img width="226" height="114" alt="Screenshot 2026-07-01 222021" src="https://github.com/user-attachments/assets/c5927fd2-1690-43b2-9f35-3e2e38fa82e8" />
<img width="217" height="124" alt="Screenshot 2026-07-01 222026" src="https://github.com/user-attachments/assets/6f84ab4a-bbf2-4712-96ed-c776b3c4b450" />
<img width="250" height="129" alt="Screenshot 2026-07-01 222137" src="https://github.com/user-attachments/assets/4e295a1f-ac78-427e-939a-ae4438646d4e" />
<img width="281" height="261" alt="Screenshot 2026-07-01 222202" src="https://github.com/user-attachments/assets/2aaabd3e-8042-4938-b071-f7255ba9814b" />
<img width="281" height="325" alt="Screenshot 2026-07-01 222313" src="https://github.com/user-attachments/assets/ad02ebc1-8756-4ecd-a2a9-39d6f93d868e" />

---

I will be sad if it breaks, and will try desperately to fix it