### PR TITLE
Hag True Form Buff and fix. Desert Town Mechanic Compatibility.

### DIFF
--- a/code/modules/jobs/job_types/roguetown/adventurer/types/antag/hag_class/hag_spells/hag_wildshape.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/antag/hag_class/hag_spells/hag_wildshape.dm
@@ -9,7 +9,7 @@
 		return
 
 	var/area/A = get_area(H)
-	if(!istype(A, /area/rogue/outdoors/bog) && !istype(A, /area/rogue/indoors/shelter/bog) && !istype(A, /area/rogue/indoors/shelter/bog_hag))
+	if(!istype(A, /area/rogue/outdoors/bog) && !istype(A, /area/rogue/indoors/shelter/bog) && !istype(A, /area/rogue/indoors/shelter/bog_hag) && !istype(A, /area/underwater) && !istype(A, /area/rogue/outdoors/desertdeep) && !istype(A, /area/rogue/indoors/shelter/desertdeep) && !istype(A, /area/rogue/under/underdarker/undermire)) //Caustic Edit - Add Underwater and Desert Town Specifics to the permitted areas.
 		to_chat(H, span_userdanger("The purity of the air shatters my form!"))
 
 		// Grab the human inside before we untransform
@@ -43,22 +43,23 @@
 	blocksound = SOFTHIT
 	blade_dulling = DULLING_BASHCHOP
 	sewrepair = FALSE
-	max_integrity = 350
+	max_integrity = 400 //Caustic Edit - 350 to 400 Integrity
 	item_flags = DROPDEL
 
 /mob/living/carbon/human/species/wildshape/hag/gain_inherent_skills()
 	. = ..()
 	if(mind)
-		STASTR = 12
-		STACON = 15
-		STAWIL = 15
+		STASTR = 13 //Caustic Edit - 12 to 13 Strength Increase
+		STACON = 16 //Caustic Edit - 15 to 16 Con Increase
+		STAWIL = 16 //Caustic Edit - 15 to 16 WIL Increase
 		STAPER = 12
-		STASPD = 8
+		STASPD = 10 //Caustic Edit - 8 to 10 SPD Increase
 		adjust_skillrank(/datum/skill/combat/wrestling, SKILL_LEVEL_JOURNEYMAN, TRUE)
 		adjust_skillrank(/datum/skill/combat/unarmed, SKILL_LEVEL_EXPERT, TRUE)
 		adjust_skillrank(/datum/skill/misc/swimming, SKILL_LEVEL_JOURNEYMAN, TRUE)
 		adjust_skillrank(/datum/skill/misc/athletics, SKILL_LEVEL_MASTER, TRUE)
 		adjust_skillrank(/datum/skill/misc/sneaking, SKILL_LEVEL_EXPERT, TRUE)
+		adjust_skillrank(/datum/skill/misc/climbing, SKILL_LEVEL_EXPERT, TRUE)
 
 		AddSpell(new /obj/effect/proc_holder/spell/self/hagclaws) 
 		apply_status_effect(/datum/status_effect/debuff/hag_bog_tether/wildshape)
@@ -70,6 +71,7 @@
 	pronouns = stored_mob.pronouns
 	//Caustic Edit End
 
+//Cautic Edit Darkvision and No Mood was missing, Battle Ready Added since Wildshaping is eating 800 Energy from Hag
 /datum/species/hag_true_form
 	name = "True Hag"
 	id = "hag_true_form"
@@ -77,12 +79,15 @@
 	inherent_traits = list(
 		TRAIT_DODGEEXPERT,
 		TRAIT_STEELHEARTED,
+		TRAIT_BREADY,
 		TRAIT_ORGAN_EATER,
 		TRAIT_HARDDISMEMBER,
 		TRAIT_PIERCEIMMUNE,
 		TRAIT_LONGSTRIDER,
 		TRAIT_KNEESTINGER_IMMUNITY,
+		TRAIT_DARKVISION,
 		TRAIT_LEECHIMMUNE,
+		TRAIT_NOMOOD,
 		TRAIT_AZURENATIVE
 	)
 	no_equip = list(SLOT_SHIRT, SLOT_HEAD, SLOT_WEAR_MASK, SLOT_ARMOR, SLOT_GLOVES, SLOT_SHOES, SLOT_PANTS, SLOT_CLOAK, SLOT_BELT, SLOT_BACK_R, SLOT_BACK_L, SLOT_S_STORE)
@@ -119,7 +124,7 @@
 		return FALSE
 
 	var/area/A = get_area(user)
-	if(!istype(A, /area/rogue/outdoors/bog) && !istype(A, /area/rogue/indoors/shelter/bog) && !istype(A, /area/rogue/indoors/shelter/bog_hag) && !istype(A, /area/underwater)) //Caustic Edit - Add Underwater to the permitted areas.
+	if(!istype(A, /area/rogue/outdoors/bog) && !istype(A, /area/rogue/indoors/shelter/bog) && !istype(A, /area/rogue/indoors/shelter/bog_hag) && !istype(A, /area/underwater) && !istype(A, /area/rogue/outdoors/desertdeep) && !istype(A, /area/rogue/indoors/shelter/desertdeep) && !istype(A, /area/rogue/under/underdarker/undermire)) //Caustic Edit - Add Underwater and Desert Town Specifics to the permitted areas.
 		to_chat(user, span_warning("The air here is too pure. I can only reveal my true self within the Terrorbog or my Hut!"))
 		revert_cast(user)
 		return FALSE
@@ -151,9 +156,9 @@
 	icon = 'icons/roguetown/weapons/misc32.dmi'
 	max_blade_int = 600
 	max_integrity = 600
-	force = 27
+	force = 30 //Caustic Edit - 27 to 30 Force the Hag Hurts Hard Now
 	block_chance = 0
-	wdefense = 6
+	wdefense = 7 //Caustic Edit - 6 to 7 wdefense
 	blade_dulling = DULLING_SHAFT_WOOD
 	associated_skill = /datum/skill/combat/unarmed
 	wlength = WLENGTH_NORMAL

--- a/modular_deserttown/desertareas.dm
+++ b/modular_deserttown/desertareas.dm
@@ -499,6 +499,25 @@
 	first_time_text = "The WasteMire"
 	deathsight_message = "a filthy swamp, far beneath the dunes"
 
+/area/rogue/under/underdarker/undermire/Entered(atom/moveable/AM)
+	..()
+	if(!GLOB.active_hags.len)
+		return
+
+	var/mob/living/L = AM
+	if(!istype(L) || !L.client || L.stat == DEAD)
+		return
+
+	if(L in GLOB.active_hags)
+		return
+
+	if(recent_intruders[L] && recent_intruders[L] > world.time)
+		return
+
+	recent_intruders[L] = world.time + 1 MINUTES
+	for(var/mob/living/H in GLOB.active_hags)
+		to_chat(H, span_boldwarning("The roots of your sanctum shiver... a soul named [L.name] has stepped within [src.name]."))
+
 // CC - Dungeon Additions
 /area/rogue/under/cave/desertminomaze
 	name = "Labyrinth of Penance"

--- a/modular_deserttown/desertareas.dm
+++ b/modular_deserttown/desertareas.dm
@@ -499,7 +499,7 @@
 	first_time_text = "The WasteMire"
 	deathsight_message = "a filthy swamp, far beneath the dunes"
 
-/area/rogue/under/underdarker/undermire/Entered(atom/moveable/AM)
+/area/rogue/under/underdarker/undermire/Entered(atom/movable/AM)
 	..()
 	if(!GLOB.active_hags.len)
 		return

--- a/modular_deserttown/desertareas.dm
+++ b/modular_deserttown/desertareas.dm
@@ -498,6 +498,7 @@
 	name = "The WasteMire"
 	first_time_text = "The WasteMire"
 	deathsight_message = "a filthy swamp, far beneath the dunes"
+	var/list/recent_intruders = list()
 
 /area/rogue/under/underdarker/undermire/Entered(atom/movable/AM)
 	..()


### PR DESCRIPTION
## About The Pull Request

True Form Buffed.
Given Darksight and No Mood while in True Form. Battle Ready given to the form since wildshaping into it eats 800 energy for some reason

Hag can now use True form in Undermire, and Deep Dunes on Desert Town.

## Developer's checklist
<!--
Just a reminder to keep up the best practices, and to ensure that everyone has an easier time as a result! Please doublecheck that they were done!
-->
- [ ] Try to modularize as much as possible. <!--  Do this by putting stuff in the modular caustic folder, and modifying Azure code by calling your code from the places where you could put the code, for an example-->
- [ ] Mark the start and end of edits outside the caustic modular folder (if applicable) for changes made.
<!--
Do this one like so

Azure
///Caustic edit
Your code
///Caustic edit end
Azure

This makes it easier for maintainers to keep track of what's ours.
-->
- [ ] Ensure that it compiles locally, and test new features (when applicable, please record if not!), or potential issues with related features.

## Testing Evidence

<!-- Please provide evidence of testing features here, when applicable! If it is not, a quick note of this is fine. -->

## Why It's Good For The Game

<!-- What benefits does this bring to our server? How can it help players enjoy themselves more, or help lead players to more scenes? If it wasn't already chatted about over the Discord, feel free to explain your resoning and desire here for the change! Or feel free to add a link to the Discord's Suggestion thread for this change! -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- Please fill in any proper tags here that are valid for your PR! This is for the auto-changelog that is generated automatically and shown ingame. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
balance: Buffs True Hag Form
fix: fixed some hag problems
map: Hag Compatibility
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
