### PR TITLE
Adds Steelhide to Autowardry

### DIFF
--- a/code/modules/spells/spell_types/wizard/minor_aspects.dm
+++ b/code/modules/spells/spell_types/wizard/minor_aspects.dm
@@ -70,6 +70,7 @@
 	choice_spells = list(
 		/datum/action/cooldown/spell/conjure_arcyne_ward/dragonhide,
 		/datum/action/cooldown/spell/conjure_arcyne_ward/crystalhide,
+		/datum/action/cooldown/spell/conjure_arcyne_ward/steelhide,
 	)
 
 /datum/magic_aspect/lesser_augmentation


### PR DESCRIPTION
Simply adds the new magic armor spell to autowardry. Now you have a choic between con and fire resistance or con and better armor.