### PR TITLE
Quick (Magickal) Tongs Fix

### DIFF
--- a/code/modules/roguetown/roguejobs/blacksmith/tools.dm
+++ b/code/modules/roguetown/roguejobs/blacksmith/tools.dm
@@ -488,15 +488,15 @@
 /obj/item/rogueweapon/tongs/update_icon()
 	. = ..()
 	if(!hingot && !ore)
-		icon_state = "tongs"
+		icon_state = initial(icon_state) // Caustic Edit. We do not need every tong subtype to need their own update_icon proc
 	else
 		if(hingot)
 			if(hott)
-				icon_state = "tongsi1"
+				icon_state = "[initial(icon_state)]i1"
 			else
-				icon_state = "tongsi0"
+				icon_state = "[initial(icon_state)]i0"
 		else
-			icon_state = "tongsi0"
+			icon_state = "[initial(icon_state)]i0"
 
 /obj/item/rogueweapon/tongs/proc/make_unhot(input)
 	if(hott == input)
@@ -558,6 +558,7 @@
 	smeltresult = null
 	max_integrity = 15
 
+/*
 /obj/item/rogueweapon/tongs/stone/update_icon()
 	. = ..()
 	if(!hingot && !ore)
@@ -570,6 +571,7 @@
 				icon_state = "stonetongsi0"
 		else
 			icon_state = "stonetongsi0"
+*/
 
 /obj/item/rogueweapon/tongs/aalloy
 	name = "decrepit tongs"
@@ -581,6 +583,7 @@
 	color = "#bb9696"
 	sellprice = 5
 
+/*
 /obj/item/rogueweapon/tongs/aalloy/update_icon()
 	. = ..()
 	if(!hingot && !ore)
@@ -593,6 +596,7 @@
 				icon_state = "atongsi0"
 		else
 			icon_state = "atongsi0"
+*/
 
 /obj/item/rogueweapon/tongs/bronze
 	name = "bronze tongs"
@@ -604,6 +608,7 @@
 	force = 14
 	max_integrity = 300
 
+/*
 /obj/item/rogueweapon/tongs/bronze/update_icon()
 	. = ..()
 	if(!hingot && !ore)
@@ -616,6 +621,7 @@
 				icon_state = "bronzetongsi0"
 		else
 			icon_state = "bronzetongsi0"
+*/
 
 /obj/item/rogueweapon/tongs/blacksteel
 	name = "blacksteel tongs"
@@ -627,6 +633,7 @@
 	force = 20
 	max_integrity = 450
 
+/*
 /obj/item/rogueweapon/tongs/blacksteel/update_icon()
 	. = ..()
 	if(!hingot && !ore)
@@ -639,4 +646,5 @@
 				icon_state = "bs_tongsi0"
 		else
 			icon_state = "bs_tongsi0"
+*/
 //Caustic Edit End


### PR DESCRIPTION
## About The Pull Request

I have been made aware that magickal tongs from the arcyne forge spell go invisible when picking up bars.
This led me to find out that every tongs subtype has their own update_icon() proc.

Hence, I made said procs obsolete and commented them out.

I tested every /tongs subtype, but if something does break, yell at me.

---

<img width="92" height="75" alt="Screenshot 2026-07-10 114956" src="https://github.com/user-attachments/assets/def51439-b151-495d-811c-9bca089cc3f7" />
<img width="102" height="95" alt="Screenshot 2026-07-10 114959" src="https://github.com/user-attachments/assets/87316015-31e9-4ac4-acee-c3367a83e806" />
