### PR TITLE
Fix for revealing light and Add new Magic scroll

### DIFF
--- a/code/datums/magic_items/magic_item.dm
+++ b/code/datums/magic_items/magic_item.dm
@@ -18,6 +18,7 @@
 	RegisterSignal(i, COMSIG_ITEM_DROPPED, PROC_REF(on_drop))
 	RegisterSignal(i, COMSIG_ITEM_ATTACK_SELF, PROC_REF(on_use))
 	RegisterSignal(i, COMSIG_ITEM_HIT_RESPONSE, PROC_REF(on_hit_response))
+	RegisterSignal(i, COMSIG_ATOM_ATTACK_RIGHT, PROC_REF(attack_right))
 
 /datum/magic_item/proc/on_hit(obj/item/source, atom/target, mob/user, proximity_flag, click_parameters)	//when enchanted item hits a mob/living, do effect.
 
@@ -39,3 +40,5 @@
 /datum/magic_item/proc/projectile_hit(atom/fired_from, atom/movable/firer, atom/target, Angle)	//effects when shooting a protectile from an enchanted item
 
 /datum/magic_item/proc/on_hit_response(var/obj/item/I, var/mob/living/carbon/human/owner, var/mob/living/carbon/human/attacker)//use for worn items such as armor to have effects on hit.
+
+/datum/magic_item/proc/attack_right(var/obj/item/i, var/mob/living/user) // Use for when you right click on an item (like shimmering lens)

--- a/code/datums/magic_items/mundane_items/mundane.dm
+++ b/code/datums/magic_items/mundane_items/mundane.dm
@@ -48,8 +48,6 @@
 		user.change_stat(STATKEY_WIL, -1)
 		to_chat(user, span_notice("I feel mundane once more"))
 
-
-
 /datum/magic_item/mundane/xylix
 	name = "Xylix's boon"
 	description = "It almost seems to give off the faint sound of laughter."
@@ -75,18 +73,41 @@
 
 /datum/magic_item/mundane/revealinglight
 	name = "unyielding light"
-	description = "It emits a shining light."
+	description = "It emits a shining light. (Use right click to light it or dim it)"
 	glow_color = "#FFB347"
 	var/active = FALSE
 
-/datum/magic_item/mundane/revealinglight/on_use(var/obj/item/i, var/mob/living/user)
+/datum/magic_item/mundane/revealinglight/attack_right(var/obj/item/i, var/mob/living/user)
 	if(!active)
 		active = TRUE
-
-		i.light_color = "#3FBAFD"
 		to_chat(user, span_notice("I grip [i] lightly, and it abruptly lights up with shining light"))
-		i.set_light(TRUE)
-		i.light_outer_range = 6
+		i.light_system = MOVABLE_LIGHT
+		if(!i.GetComponent(/datum/component/overlay_lighting))
+			i.AddComponent(/datum/component/overlay_lighting)
+		i.set_light_range(10)
+		i.set_light_power(1)
+		i.set_light_color(LIGHT_COLOR_WHITE)
+		i.set_light_on(TRUE)
+		i.update_icon()
+	else
+		active = FALSE
+		to_chat(user, span_notice("I grip [i] lightly, and the light fades away"))
+		i.set_light_on(FALSE)
+		i.update_icon()
+	. = ..()
+
+/datum/magic_item/mundane/fairseeming
+	name = "fair seeming"
+	description = "It never seems to gather dirt. (Right click on it to activate the cleaning effect.)"
+	glow_color = "#E6C9F0"
+
+/datum/magic_item/mundane/fairseeming/attack_right(var/obj/item/i, var/mob/living/user)
+	to_chat(user, span_notice("I grip [i] lightly, and a faint shimmer of glamour gathers around me..."))
+	if(do_after(user, 2 SECONDS, target = user))
+		new /obj/effect/temp_visual/cleaning_pulse(get_turf(user))
+		wash_atom(user, CLEAN_STRONG)
+		user.remove_stress(/datum/stressevent/sewertouched)
+		to_chat(user, span_notice("The glamour settles, and I am spotless once more."))
 	. = ..()
 
 /datum/magic_item/mundane/holding

--- a/code/modules/roguetown/roguejobs/mages/enchanting_scrolls.dm
+++ b/code/modules/roguetown/roguejobs/mages/enchanting_scrolls.dm
@@ -133,6 +133,23 @@ T1 Enchantments below here*/
 	else
 		to_chat(user, span_notice("Nothing happens. Perhaps you can't enchant [O] with this?"))
 
+/obj/item/enchantmentscroll/basic/fairseeming
+	name = "enchanting scroll of fair seeming"
+	desc = "A scroll imbued with an enchantment of fair seeming. Allows an enchanted item to clean its owner."
+	component = /datum/magic_item/mundane/fairseeming
+
+/obj/item/enchantmentscroll/basic/fairseeming/attack_obj(obj/item/O, mob/living/user)
+	if(!..())
+		return
+	if(istype(O,/obj/item/clothing)|| istype(O,/obj/item/handmirror))
+		to_chat(user, span_notice("You open [src] and place [O] within. Moments later, it flashes blue with arcana, and [src] crumbles to dust."))
+		var/magiceffect= new component
+		O.AddComponent(/datum/component/magic_item, magiceffect)
+		O.name += " of fair seeming"
+		qdel(src)
+	else
+		to_chat(user, span_notice("Nothing happens. Perhaps you can't enchant [O] with this?"))
+
 //T2 Enchantments below
 
 /obj/item/enchantmentscroll/superior/nightvision

--- a/code/modules/roguetown/roguejobs/mages/rituals/enchanting.dm
+++ b/code/modules/roguetown/roguejobs/mages/rituals/enchanting.dm
@@ -30,6 +30,14 @@
 	required_atoms = list(/obj/item/rogueore/cinnabar = 1,/obj/item/paper/scroll = 1, /obj/item/magic/leyline = 1)
 	result_atoms = list(/obj/item/enchantmentscroll/basic/xylix)
 
+/datum/runeritual/enchanting/fairseeming
+	name = "Fair Seeming"
+	desc = "Become Spotless!"
+	blacklisted = FALSE
+	tier = 1
+	required_atoms = list(/obj/item/rogueore/cinnabar = 1, /obj/item/paper/scroll = 1, /obj/item/magic/fae/fairydust = 4)
+	result_atoms = list(/obj/item/enchantmentscroll/basic/fairseeming)
+
 /datum/runeritual/enchanting/revealinglight
 	name = "Revealing Light"
 	desc = "Provides light!"


### PR DESCRIPTION
Revealing light now acts as a flashlight useable with right click.

The new scroll merely adds an ability to on use clean yourself, that's it!

Credit goes to this PR: https://github.com/Azure-Peak/Azure-Peak/pull/8042