### PR TITLE
Revenants can now actually pick the Nobility virtue

### DIFF
--- a/code/modules/virtues/utility.dm
+++ b/code/modules/virtues/utility.dm
@@ -2,7 +2,7 @@
 	name = "Nobility"
 	desc = "By birth, blade or brain, I am noble known to the royalty of these lands, and have all the benefits associated with it. I've cleverly stashed away a healthy amount of coinage, alongside a familial heirloom."
 	restricted = TRUE
-	races = list(/datum/species/construct, /datum/species/dullahan)
+	races = list(/datum/species/construct) //Caustic Edit - Dullahan can be nobles
 	added_traits = list(TRAIT_NOBLE, TRAIT_EXPERT_HUNTER)
 	added_skills = list(list(/datum/skill/misc/reading, 1, 6))
 	added_stashed_items = list("Heirloom Amulet" = /obj/item/clothing/neck/roguetown/ornateamulet/noble,


### PR DESCRIPTION
## About The Pull Request

I've fixed a little error in the code. Revenants are supposed to be able to pick the Nobility virtue on here, as the species had its trait restriction removed, on dullahan.dm.
However, the trait itself still had its restriction. I simply just removed it for revenants, so that it actually works.

## Testing Evidence

<img width="260" height="394" alt="image" src="https://github.com/user-attachments/assets/b8a4e7a8-39d2-41a5-afe1-4d701fcc72d9" />

## Why It's Good For The Game

Bugfix!

:cl:
fix: Revenants can now use the Nobility trait, as intended.
/:cl:
