### PR TITLE
Makes the painter ritual ask for a random person until it finds one

### DIFF
--- a/code/modules/roguetown/roguemachine/abyssorcult/dream_rune.dm
+++ b/code/modules/roguetown/roguemachine/abyssorcult/dream_rune.dm
@@ -199,7 +199,7 @@
 	open_quest_selection_ui(user, tier_choices, src.parchment_used, tier)
 
 /obj/structure/roguemachine/ritual_rune/proc/find_valid_target_for_quest(datum/vision_quest/Q, mob/living/carbon/human/seeker)
-	for(var/mob/living/carbon/human/H in GLOB.player_list)
+	for(var/mob/living/carbon/human/H in shuffle(GLOB.player_list))
 		if(H == seeker)
 			continue
 		if(H.stat == DEAD)


### PR DESCRIPTION
## About The Pull Request

Shuffles the player list before sifting through it for painter quests
Not going to modularize it because it will probably be submitted upstream once or at the very least tell Ketrai

## Developer's checklist
<!--
Just a reminder to keep up the best practices, and to ensure that everyone has an easier time as a result! Please doublecheck that they were done!
-->
- [ ] Try to modularize as much as possible. <!--  Do this by putting stuff in the modular caustic folder, and modifying Azure code by calling your code from the places where you could put the code, for an example-->
- [ ] Mark the start and end of edits outside the caustic modular folder (if applicable) for changes made.
<!--
Do this one like so

Azure
///Caustic edit
Your code
///Caustic edit end
Azure

This makes it easier for maintainers to keep track of what's ours.
-->
- [x] Ensure that it compiles locally, and test new features (when applicable, please record if not!), or potential issues with related features.

## Testing Evidence

Prod

## Why It's Good For The Game

Don't believe it was intended to be a single person only

## Changelog
<!-- Please fill in any proper tags here that are valid for your PR! This is for the auto-changelog that is generated automatically and shown ingame. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
fix: Abyssorite ritual now picks from random targets
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
