### PR TITLE
Hopefully fixes end of round runtimes and the lags that possibly result because of it

### DIFF
--- a/code/__HELPERS/roundend.dm
+++ b/code/__HELPERS/roundend.dm
@@ -94,12 +94,14 @@
 	if(SSticker.current_state != GAME_STATE_FINISHED)
 		return
 	status_flags |= GODMODE
-	ai_controller?.set_ai_status(AI_STATUS_OFF)
 	if(client)
 		add_verb(client, /client/proc/lobbyooc)
 		add_verb(client, /client/proc/view_stats)
 		client.init_verbs()
 		client.show_game_over()
+		return
+	if(ai_controller)
+		ai_controller.set_ai_status(AI_STATUS_OFF)
 
 /mob/living/do_game_over()
 	..()


### PR DESCRIPTION
## About The Pull Request

Rewrote the end round thing just a bit to be safer hopefully, by checking if we have a client first, and if not, then check if we have a controller, and if so, then try to set the ai mode. No modularization because if it works it's going upstream

## Developer's checklist
<!--
Just a reminder to keep up the best practices, and to ensure that everyone has an easier time as a result! Please doublecheck that they were done!
-->
- [ ] Try to modularize as much as possible. <!--  Do this by putting stuff in the modular caustic folder, and modifying Azure code by calling your code from the places where you could put the code, for an example-->
- [ ] Mark the start and end of edits outside the caustic modular folder (if applicable) for changes made.
<!--
Do this one like so

Azure
///Caustic edit
Your code
///Caustic edit end
Azure

This makes it easier for maintainers to keep track of what's ours.
-->
- [ ] Ensure that it compiles locally, and test new features (when applicable, please record if not!), or potential issues with related features.

## Testing Evidence

Prod

## Why It's Good For The Game

At the end of most rounds, the game dies for a solid half a minute during which the end title credits should play but instead the game goes on as normal. This is the only runtime I could have found. Hope this fixes it? Silly deadites and their incomplete implementation.

## Changelog
<!-- Please fill in any proper tags here that are valid for your PR! This is for the auto-changelog that is generated automatically and shown ingame. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
fix: MobAI is now checked before being set
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
