### PR TITLE
Organ eater fix (i like hard vore so i noticed ok)

### DIFF
--- a/code/modules/roguetown/roguecrafting/alchemy/reagents.dm
+++ b/code/modules/roguetown/roguecrafting/alchemy/reagents.dm
@@ -426,7 +426,7 @@ If you want to expand on poisons theres tons of fun effects TG chemistry has tha
 /datum/reagent/organpoison/on_mob_life(mob/living/carbon/M)
 	if(HAS_TRAIT(M, TRAIT_NASTY_EATER) || HAS_TRAIT(M, TRAIT_ORGAN_EATER) || HAS_TRAIT(M, TRAIT_WILD_EATER))
 		M.energy_add(10) //Slowly add energy back.
-	if(!HAS_TRAIT(M, TRAIT_NASTY_EATER) && !HAS_TRAIT(M, TRAIT_ORGAN_EATER))
+	else
 		M.add_nausea(9)
 		M.adjustToxLoss(2)
 	return ..()

--- a/code/modules/roguetown/roguecrafting/alchemy/reagents.dm
+++ b/code/modules/roguetown/roguecrafting/alchemy/reagents.dm
@@ -424,7 +424,7 @@ If you want to expand on poisons theres tons of fun effects TG chemistry has tha
 
 
 /datum/reagent/organpoison/on_mob_life(mob/living/carbon/M)
-	if(HAS_TRAIT(M, TRAIT_ORGAN_EATER))
+	if(HAS_TRAIT(M, TRAIT_NASTY_EATER) || HAS_TRAIT(M, TRAIT_ORGAN_EATER) || HAS_TRAIT(M, TRAIT_WILD_EATER))
 		M.energy_add(10) //Slowly add energy back.
 	if(!HAS_TRAIT(M, TRAIT_NASTY_EATER) && !HAS_TRAIT(M, TRAIT_ORGAN_EATER))
 		M.add_nausea(9)

--- a/code/modules/roguetown/roguecrafting/alchemy/reagents.dm
+++ b/code/modules/roguetown/roguecrafting/alchemy/reagents.dm
@@ -424,8 +424,10 @@ If you want to expand on poisons theres tons of fun effects TG chemistry has tha
 
 
 /datum/reagent/organpoison/on_mob_life(mob/living/carbon/M)
-	if(HAS_TRAIT(M, TRAIT_NASTY_EATER) || HAS_TRAIT(M, TRAIT_ORGAN_EATER) || HAS_TRAIT(M, TRAIT_WILD_EATER))
+	if(HAS_TRAIT(M, TRAIT_ORGAN_EATER))
 		M.energy_add(10) //Slowly add energy back.
+	if(HAS_TRAIT(M, TRAIT_NASTY_EATER) || HAS_TRAIT(M, TRAIT_WILD_EATER))
+		return
 	else
 		M.add_nausea(9)
 		M.adjustToxLoss(2)

--- a/code/modules/surgery/organs/organ_internal.dm
+++ b/code/modules/surgery/organs/organ_internal.dm
@@ -175,6 +175,8 @@
 	if(HAS_TRAIT(eater, TRAIT_ORGAN_EATER))
 		eat_effect = /datum/status_effect/buff/snackbuff
 		foodtype = RAW | MEAT
+	if(HAS_TRAIT(eater, TRAIT_NASTY_EATER) || HAS_TRAIT(eater, TRAIT_WILD_EATER))
+		foodtype = RAW | MEAT
 	else
 		eat_effect = initial(eat_effect)
 		foodtype = initial(foodtype)

--- a/code/modules/virtues/combat.dm
+++ b/code/modules/virtues/combat.dm
@@ -199,7 +199,7 @@
 		SC_BLACKBLOOD,
 	)
 	choice_tooltips = list(
-		SC_ROTCURED = "<font color='#4a8d48'>I was once afflicted with the accursed rot, and was cured. It has left me changed: my limbs are weaker, but I feel no pain and have no need to breathe.<br><br><font color=red>(Grants Easy Dismember, Painless, Breathless, Deathless, Poison Immune, Deadite Immune, Silver Weakness.)<font color=white><br><br>(Additionally, you can eat brains, you don't suffer nausea, and your heart does not beat.)</font>",
+		SC_ROTCURED = "<font color='#4a8d48'>I was once afflicted with the accursed rot, and was cured. It has left me changed: my limbs are weaker, but I feel no pain and have no need to breathe.<br><br><font color=red>(Grants Easy Dismember, Painless, Breathless, Deathless, Poison Immune, Deadite Immune, Inhumen Digestion, Nightvision, Silver Weakness.)<font color=white><br><br>(Additionally, you can eat brains, you don't suffer nausea, and your heart does not beat.)</font>",
 		SC_PALLID = "<font color='#8d4848'>I was once afflicted with vampirism, but was cured by somethign short of divine intervention. It has left me changed: silver burns my flesh, and the open sky fills me with unease. Yet I draw no breath, and my eyes pierce the darkness. Lingering traces of the curse that once claimed me. Traces I hope will fade in time.<br><br><font color=red>(Grants Darkvision, Breathless, Deadite Immunity and Silver Weakness.)<br><br><font color=white>(Additionally, being outdoors causes stress.)</font>",
 		SC_BLACKBLOOD = "<font color='#8b488d'>I was once a nite-creacher, be it lycanthrope or vampyre, before the Otavan Inquisition subdued and exported me as a test subject of an experimental \"cure\" for my Quicksilver-resistant taint. This intense therapy had me warped, inside, outside, body and mind, into something 'idealistically' humen-like for Otavan standards, even if I am now no different than a sentient, hollowed ghoul.<br><br><font color=red>(Grants Darkvision, Leaden Lux, Strong Bite, Inhumen Digestion, and Silver Weakness.)<br><br><font color=white>(Additionally, consuming any food will grant a minor healing buff. You bleed slower and passively recover from wounds (while not hungry). You will feel stressed when exposed to Sunlight, and panic while being around or interacting with members of the Inquisition.)",
 	)
@@ -223,6 +223,8 @@
 					ADD_TRAIT(recipient, TRAIT_NOBREATH, TRAIT_VIRTUE)
 					ADD_TRAIT(recipient, TRAIT_DEATHLESS, TRAIT_VIRTUE)
 					ADD_TRAIT(recipient, TRAIT_TOXIMMUNE, TRAIT_VIRTUE)
+					ADD_TRAIT(recipient, TRAIT_NASTY_EATER, TRAIT_VIRTUE)
+					ADD_TRAIT(recipient, TRAIT_NITEVISION, TRAIT_VIRTUE)
 					ADD_TRAIT(recipient, TRAIT_ZOMBIE_IMMUNE, TRAIT_VIRTUE)
 					ADD_TRAIT(recipient, TRAIT_SILVER_WEAK, TRAIT_VIRTUE)
 					to_chat(recipient, "You are no longer a rotting corpse, at least not a dying one.</font>")

--- a/modular/Neu_Food/code/recipes/stew_recipes.dm
+++ b/modular/Neu_Food/code/recipes/stew_recipes.dm
@@ -360,9 +360,9 @@
 	cooktime = STEW_COOKING_TIME * 2 //A little longer to break down all of the deliciousness.
 
 /datum/stew_recipe/viscera
-	inputs = list(/obj/item/organ/appendix, /obj/item/organ/lungs, /obj/item/organ/liver, /obj/item/organ/stomach, /obj/item/organ/ears, /obj/item/organ/eyes, /obj/item/alch/viscera, /obj/item/alch/sinew)
+	inputs = list(/obj/item/organ/appendix, /obj/item/organ/lungs, /obj/item/organ/liver, /obj/item/organ/stomach, /obj/item/organ/ears, /obj/item/organ/eyes, /obj/item/organ/brain, /obj/item/organ/heart, /obj/item/alch/viscera, /obj/item/alch/sinew)
 	output = /datum/reagent/consumable/soup/stew/viscera_broth
-	cooktime = STEW_COOKING_TIME * 2 //Ditto. No hearts or brains, in order to avoid potentially permakilling someone. Could find a way to handle this, otherwise.
+	cooktime = STEW_COOKING_TIME * 2
 
 /datum/stew_recipe/brothbrique
 	inputs = list(/obj/item/reagent_containers/food/snacks/rogue/meat/brothbrique/slice)


### PR DESCRIPTION
so, others might not of noticed it but im a freek so I did. this fix's puking when you eat brains or organs as rotcured or anyone with inhumen digestion. as it stood zombo puked from eating brains even tho... they only ones that can. and ANYONE puked eating organs not a graggarite because the organ poison still effected them.

also added nightvision for rotcured because... they are jsut as undead as the rest. and im tired of sticking undead eyes into me every round and ruining my green eyes

-added inhumen digestion for organs and nightvision to rutcured

-fixed organ poisoning effecting thos it shouldnt

-added hearts and brains to make offal stew with (the reason they couldnt was said to not RR people but you could eat them anyway without stewing them? weird reasoning... also no ones RRing like that here it isnt ratwood.)